### PR TITLE
change name of main() function in exotransmit C code

### DIFF
--- a/ExoCTK/pal/_exotransmit_wrapper.pyx
+++ b/ExoCTK/pal/_exotransmit_wrapper.pyx
@@ -4,7 +4,7 @@ generates transmission spectra to study exoplanet atmospheres.
 """
 
 cdef extern from "include/main_transmission.c":
-    void main()
+    void main_transmission()
 
 def exotransmit():
-    main()
+    main_transmission()

--- a/ExoCTK/pal/include/main_transmission.c
+++ b/ExoCTK/pal/include/main_transmission.c
@@ -40,7 +40,7 @@ struct Chem chem;
 /* ------- begin ---------------- main --------------------------- */
 
 
-int main()
+int main_transmission()
 {
   TotalOpac();
   printf("TotalOpac done\n");


### PR DESCRIPTION
This causes a bug where the Python prompt starts when exotransmit is run, presumably do to some naming conflict with "main".