### PR TITLE
Rebinned filters so that wavelengths are evenly spaced

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ author_email = jfilippazzo@stsci.edu
 license = BSD
 edit_on_github = True
 github_project = ExoCTK/ExoCTK
-install_requires = numpy scipy cython matplotlib numba pysynphot sphinx_automodapi sphinx_rtd_theme bibtexparser bokeh batman-package
+install_requires = numpy scipy cython matplotlib numba pysynphot sphinx_automodapi sphinx_rtd_theme bokeh batman-package
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
 version = 0.1.3dev
 external_files = /user/jfilippazzo/Models/ExoCTK/


### PR DESCRIPTION
Kevin noted that the wavelength spacing of the grism throughputs were not uniform so rebinning resulted in uneven wavelength ranges. Fixed.