### PR TITLE
Commented out matplotlib.use('Agg')

### DIFF
--- a/ExoCTK/contam_visibility/visibilityPA.py
+++ b/ExoCTK/contam_visibility/visibilityPA.py
@@ -14,7 +14,7 @@ import math
 import pkg_resources
 
 import matplotlib
-matplotlib.use('Agg')
+# matplotlib.use('Agg')
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MultipleLocator


### PR DESCRIPTION
The use of matplotlib.use('Agg') makes it tedious to use `ExoCTK` in an analysis framework, such as when implementing it inside of `AWESim_SOSS`.  It may be necessary for the `ExoCTKWeb`; but let the web app implemented it.