### PR TITLE
Added asteval dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(name='exoctk',
       version='0.2.2',
       description='Observation reduction and planning tools for exoplanet science',
-      install_requires=['numpy', 'astropy', 'scipy', 'cython', 'matplotlib', 'numba', 'pysynphot', 'sphinx_automodapi', 'sphinx_rtd_theme', 'bibtexparser', 'bokeh', 'pandas', 'svo_filters', 'sphinx_astropy', 'batman-package', 'lmfit', 'flask'],
+      install_requires=['numpy', 'astropy', 'scipy', 'cython', 'matplotlib', 'numba', 'pysynphot', 'sphinx_automodapi', 'sphinx_rtd_theme', 'bibtexparser', 'bokeh', 'pandas', 'svo_filters', 'sphinx_astropy', 'batman-package', 'lmfit', 'flask', 'asteval'],
       author='The ExoCTK Group',
       author_email='exoctk@gmail.com',
       license='MIT',


### PR DESCRIPTION
When trying to import `exoctk` there is a dependency on `asteval` that was not in the `setup.py` file.