### PR TITLE
Added Exomast API retrieval for Groups and Integrations

### DIFF
--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -27,7 +27,7 @@ from exoctk.contam_visibility import sossFieldSim as fs
 from exoctk.contam_visibility import sossContamFig as cf
 from exoctk.groups_integrations.groups_integrations import perform_calculation
 from exoctk.limb_darkening import limb_darkening_fit as lf
-from exoctk.utils import find_closest, filter_table, get_target_data
+from exoctk.utils import find_closest, filter_table, get_target_data, get_canonical_name
 import log_exoctk
 from svo_filters import svo
 from sqlalchemy import create_engine
@@ -320,6 +320,19 @@ def groups_integrations():
     # Print out pandeia sat values
     with open(resource_filename('exoctk', 'data/groups_integrations/groups_integrations_input_data.json')) as f:
         sat_data = json.load(f)['fullwell']
+
+    if request.method == 'POST':
+        if request.form['submit'] == "Retrieve Parameters":
+            target_name = request.form['targetname']
+            canoncial_name = get_canonical_name(target_name)
+            # Ping exomast api and get data
+            data = get_target_data(target_name)
+            Kmag = data['Kmag']
+            obs_duration = data['transit_duration'] * 24. # Transit duration in exomast is in days, need it in hours
+            
+            groupsintegrationVars = {'targname':canoncial_name, 'Kmag':Kmag, 'obs_duration':obs_duration}
+
+            return render_template('groups_integrations.html', sat_data=sat_data, groupsintegrationVars=groupsintegrationVars)
 
     return render_template('groups_integrations.html', sat_data=sat_data)
 

--- a/exoctk/exoctk_app/templates/groups_integrations.html
+++ b/exoctk/exoctk_app/templates/groups_integrations.html
@@ -71,16 +71,34 @@
             means we may predict less groups -- and put you in LESS danger of
             oversaturating your observation.)</p> 
 
-    <form class='form-horizontal' id='searchform' method='post' action='groups_integrations_results' >
+    <form class='form-horizontal' id='searchform' method='post'>
         
         <hr class="col-md-12">
-        
+        <div class='form-group'>
+            
+                <label for='mag' class="col-sm-2 control-label">ExoMAST Retrieval</label>
+                <div class="col-sm-10">
+                        <div class="input-group">
+                            <input type="text" name="targetname" placeholder="WASP-18 b" value="{{ groupsintegrationVars['targname'] }}" size="30" maxlength="110"/><br>
+                        </div>
+      
+                        <br>
+      
+                        <div class="input-group">
+                            <input class="btn btn-success" type="submit" name="submit" value="Retrieve Parameters"/>
+                        </div>
+                     <span id="helpBlock" class="help-block">Get form data from ExoMAST</span>
+                </div>
+                
+            </div>
+        <hr class="col-md-12">
+
         <div class='form-group'>
             
             <label for='mag' class="col-sm-2 control-label">Stellar Parameters</label>
             <div class="col-sm-10">
                 <div class="input-group">
-                    <input type="text" name="mag" size="7" rows="1" placeholder="magnitude" class='form-control' />
+                    <input type="text" name="mag" size="7" rows="1" placeholder="magnitude" value="{{ groupsintegrationVars['Kmag'] }}" class='form-control' />
                     <div class="input-group-addon" style='width:50px'>\(\small \text{mag}\)</div>
                  </div>
                  <span id="helpBlock" class="help-block">The vega magnitude of the target.</span>
@@ -163,7 +181,7 @@
             <label for='obs_time' class="col-sm-2 control-label">Observation Time</label>
             <div class="col-sm-10">
                 <div class="input-group">
-                    <input type="text" name="obs_time" size="7" rows="1" placeholder="time" class='form-control' />
+                    <input type="text" name="obs_time" size="7" rows="1" placeholder="time" value="{{ groupsintegrationVars['obs_duration'] }}" class='form-control' />
                     <div class="input-group-addon" style='width:50px'>\(\small \text{hours}\)</div>
                  </div>
                  <span id="helpBlock" class="help-block">The length of the observation in hours</span>


### PR DESCRIPTION
Added the basic retrieval functionality. Was thinking maybe in the future, we could break up the model drop down for stellar type, teff, and log(g) into separate buttons and then select the upper or lower limit of allowed values for the models based on whats returned from the API call.