### PR TITLE
Install for ExoMast: Setting zip_safe to True

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(name='exoctk',
       license='MIT',
       url='https://github.com/ExoCTK/exoctk',
       long_description='',
-      zip_safe=False,
+      zip_safe=True,
       use_2to3=False
 )


### PR DESCRIPTION
This PR simply switches the `zip_safe` parameter in `setup.py` to `True` to help the ExoMast team more easily install the `exoctk` package.

This pertains to #202 