### PR TITLE
[WIP] Adding resolve button to groups and integrations calculator

### DIFF
--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -328,22 +328,39 @@ def groups_integrations():
     if request.method == 'GET':       
         try: 
             # http://0.0.0.0:5000/groups_integrations?k_mag=10.602&transit_duration=0.0655
+            target_name = request.args.get('target')
             k_mag = request.args.get('k_mag')
             trans_dur = float(request.args.get('transit_duration'))
             # According to Kevin the obs_dur = 3*trans_dur+1 hours
             # transit_dur is in days from exomast, convert first.
             trans_dur *= u.day.to(u.hour)
-            print(type(trans_dur))
             obs_dur = 3*trans_dur + 1
-            print(obs_dur)
             
-            groupIntVars = {'k_mag':k_mag, 
+            groupIntVars = {'tname':target_name,
+                            'k_mag':k_mag, 
                             'obs_dur':obs_dur}
 
             return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars=groupIntVars)
             
         except TypeError:
             return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars={})
+
+    elif request.method == 'POST':
+        if request.form['submit'] == "Resolve Target":
+            target_name = request.form['targetname']
+            data, target_url = get_target_data(target_name, request_url=True)
+            k_mag = data['Kmag']
+            trans_dur = data['transit_duration']
+            # According to Kevin the obs_dur = 3*trans_dur+1 hours
+            # transit_dur is in days from exomast, convert first.
+            trans_dur *= u.day.to(u.hour)
+            obs_dur = 3*trans_dur + 1
+            
+            groupIntVars = {'tname':target_name,
+                            'k_mag':k_mag, 
+                            'obs_dur':obs_dur}
+
+            return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars=groupIntVars)
 
     return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars={})
 

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -327,19 +327,23 @@ def groups_integrations():
 
     if request.method == 'GET':       
         try: 
-            # http://0.0.0.0:5000/groups_integrations?k_mag=10.602&transit_duration=0.0655
-            target_name = request.args.get('target')
-            k_mag = request.args.get('k_mag')
-            trans_dur = float(request.args.get('transit_duration'))
+            # http://0.0.0.0:5000/groups_integrations?k_mag=10.602&transit_duration=0.0655&target=WASP-1%20b
+            target_name = request.args.get('target', type=str)
+            k_mag = request.args.get('k_mag', type=float)
+            trans_dur = request.args.get('transit_duration', type=float)
+            print(target_name, k_mag, trans_dur)
             # According to Kevin the obs_dur = 3*trans_dur+1 hours
             # transit_dur is in days from exomast, convert first.
-            trans_dur *= u.day.to(u.hour)
-            obs_dur = 3*trans_dur + 1
-            
+            if trans_dur is not None:
+                trans_dur *= u.day.to(u.hour)
+                obs_dur = 3*trans_dur + 1
+            else:
+                obs_dur = None
+
             groupIntVars = {'tname':target_name,
                             'k_mag':k_mag, 
                             'obs_dur':obs_dur}
-
+            
             return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars=groupIntVars)
             
         except TypeError:

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -93,11 +93,14 @@ def limb_darkening():
         target_name = request.args.get('targetname', default='Wasp-18 b')
         target_name = urllib.parse.unquote(target_name, encoding='utf-8') 
         
-        teff = request.args.get('teff', default=3624.0)
-        logg = request.args.get('logg', default=5.22)
-        feh = request.args.get('feh', default=0.0)
+        teff = request.args.get('teff', default=6431.0)
+        logg = request.args.get('logg', default=4.47)
+        feh = request.args.get('feh', default=0.13)
+        target_url = 'https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP18b'
         
-        limbVars = {'targname':target_name, 'feh': feh, 'teff':teff, 'logg':logg}
+        limbVars = {'targname':target_name, 'feh': feh, 
+                    'teff':teff, 'logg':logg, 
+                    'target_url':target_url}
 
         return render_template('limb_darkening.html', limbVars=limbVars, filters=filt_list)
 
@@ -111,7 +114,8 @@ def limb_darkening():
             logg = data['stellar_gravity']
             
             limbVars = {'targname':target_name, 'feh': feh, 
-                        'teff':teff, 'logg':logg}
+                        'teff':teff, 'logg':logg,
+                        'target_url':target_url}
 
             return render_template('limb_darkening.html', limbVars=limbVars, filters=filt_list)
 

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -93,9 +93,9 @@ def limb_darkening():
         target_name = request.args.get('targetname', default='Wasp-18 b')
         target_name = urllib.parse.unquote(target_name, encoding='utf-8') 
         
-        feh = request.args.get('feh', default=0.0)
         teff = request.args.get('teff', default=3624.0)
         logg = request.args.get('logg', default=5.22)
+        feh = request.args.get('feh', default=0.0)
         
         limbVars = {'targname':target_name, 'feh': feh, 'teff':teff, 'logg':logg}
 
@@ -104,13 +104,14 @@ def limb_darkening():
     if request.method == 'POST':
         if request.form['submit'] == "Retrieve Parameters":
             target_name = request.form['targetname']
-            data = get_target_data(target_name)
+            data, target_url = get_target_data(target_name, request_url=True)
 
             feh = data['Fe/H']
             teff = data['Teff']
             logg = data['stellar_gravity']
             
-            limbVars = {'targname':target_name, 'feh': feh, 'teff':teff, 'logg':logg}
+            limbVars = {'targname':target_name, 'feh': feh, 
+                        'teff':teff, 'logg':logg}
 
             return render_template('limb_darkening.html', limbVars=limbVars, filters=filt_list)
 

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -326,24 +326,24 @@ def groups_integrations():
 
 
     if request.method == 'GET':       
-        # try: 
-        # http://0.0.0.0:5000/groups_integrations?k_mag=10.602&transit_duration=0.0655
-        k_mag = request.args.get('k_mag')
-        trans_dur = float(request.args.get('transit_duration'))
-        # According to Kevin the obs_dur = 3*trans_dur+1 hours
-        # transit_dur is in days from exomast, convert first.
-        trans_dur *= u.day.to(u.hour)
-        print(type(trans_dur))
-        obs_dur = 3*trans_dur + 1
-        print(obs_dur)
-        
-        groupIntVars = {'k_mag':k_mag, 
-                        'obs_dur':obs_dur}
+        try: 
+            # http://0.0.0.0:5000/groups_integrations?k_mag=10.602&transit_duration=0.0655
+            k_mag = request.args.get('k_mag')
+            trans_dur = float(request.args.get('transit_duration'))
+            # According to Kevin the obs_dur = 3*trans_dur+1 hours
+            # transit_dur is in days from exomast, convert first.
+            trans_dur *= u.day.to(u.hour)
+            print(type(trans_dur))
+            obs_dur = 3*trans_dur + 1
+            print(obs_dur)
+            
+            groupIntVars = {'k_mag':k_mag, 
+                            'obs_dur':obs_dur}
 
-        return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars=groupIntVars)
-        
-        # except TypeError:
-        #     return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars={})
+            return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars=groupIntVars)
+            
+        except TypeError:
+            return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars={})
 
     return render_template('groups_integrations.html', sat_data=sat_data, groupIntVars={})
 

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -19,6 +19,7 @@ from flask import request, send_file, make_response, render_template, redirect
 from functools import wraps
 import numpy as np
 import pandas as pd
+import urllib
 
 from exoctk.modelgrid import ModelGrid
 from exoctk.contam_visibility import resolve
@@ -84,6 +85,21 @@ def limb_darkening():
 
     # Make HTML for filters
     filt_list = '\n'.join(['<option value="{0}"{1}> {0}</option>'.format(b, ' selected' if b == 'Kepler.K' else '') for b in filters])
+
+    if request.method == 'GET':
+        # Dummy url: 0.0.0.0:5000/limb_darkening?targetname=Wasp-39%20b&teff=5400.0&logg=4.4&feh=-0.12
+        
+        # Target name will be decoded ie Wasp-39 b == Wasp-39%20b
+        target_name = request.args.get('targetname', default='Wasp-18 b')
+        target_name = urllib.parse.unquote(target_name, encoding='utf-8') 
+        
+        feh = request.args.get('feh', default=0.0)
+        teff = request.args.get('teff', default=3624.0)
+        logg = request.args.get('logg', default=5.22)
+        
+        limbVars = {'targname':target_name, 'feh': feh, 'teff':teff, 'logg':logg}
+
+        return render_template('limb_darkening.html', limbVars=limbVars, filters=filt_list)
 
     if request.method == 'POST':
         if request.form['submit'] == "Retrieve Parameters":

--- a/exoctk/exoctk_app/templates/groups_integrations.html
+++ b/exoctk/exoctk_app/templates/groups_integrations.html
@@ -86,7 +86,7 @@
                 <div class="input-group">
                     <input class="btn btn-success" type="submit" name="submit" value="Resolve Target"/>
                 </div>
-                <span id="helpBlock" class="help-block">If target is unresolved, reload page and enter coordinates manually</span>
+                <span id="helpBlock" class="help-block">If target is unresolved, reload page and enter parameters manually</span>
             </div>
 
 

--- a/exoctk/exoctk_app/templates/groups_integrations.html
+++ b/exoctk/exoctk_app/templates/groups_integrations.html
@@ -80,7 +80,7 @@
             <label for='mag' class="col-sm-2 control-label">Stellar Parameters</label>
             <div class="col-sm-10">
                 <div class="input-group">
-                    <input type="text" name="mag" size="7" rows="1" placeholder="magnitude" class='form-control' />
+                    <input type="text" name="mag" size="7" rows="1" placeholder="magnitude" value="{{ groupIntVars['k_mag'] }}" class='form-control' />
                     <div class="input-group-addon" style='width:50px'>\(\small \text{mag}\)</div>
                  </div>
                  <span id="helpBlock" class="help-block">The vega magnitude of the target.</span>
@@ -163,10 +163,11 @@
             <label for='obs_time' class="col-sm-2 control-label">Observation Time</label>
             <div class="col-sm-10">
                 <div class="input-group">
-                    <input type="text" name="obs_time" size="7" rows="1" placeholder="time" class='form-control' />
+                    <input type="text" name="obs_time" size="7" rows="1" placeholder="time" value="{{ groupIntVars['obs_dur'] }}" class='form-control' />
                     <div class="input-group-addon" style='width:50px'>\(\small \text{hours}\)</div>
                  </div>
                  <span id="helpBlock" class="help-block">The length of the observation in hours</span>
+                 <span id="helpBlock" class="help-block">If you are coming from EXOMAST, we convert from days to hours and calculate using <code>observation_duration = 3*transit_duration+1</code></span>
             </div>
             
         </div>

--- a/exoctk/exoctk_app/templates/groups_integrations.html
+++ b/exoctk/exoctk_app/templates/groups_integrations.html
@@ -71,10 +71,31 @@
             means we may predict less groups -- and put you in LESS danger of
             oversaturating your observation.)</p> 
 
-    <form class='form-horizontal' id='searchform' method='post' action='groups_integrations_results' >
+    <form class='form-horizontal' id='searchform' method='post'>
         
         <hr class="col-md-12">
         
+
+        <div class='form-group'>
+            <label for='mag' class="col-sm-2 control-label">Resolve Target</label>
+            <div class="col-sm-10">
+                <div class="input-group">
+                    <input type="text" name="targetname" value = "{{ groupIntVars['tname'] }}" size="30" maxlength="110"/><br>
+                </div>
+                <span id="helpBlock" class="help-block">Please enter target name</span>
+                <div class="input-group">
+                    <input class="btn btn-success" type="submit" name="submit" value="Resolve Target"/>
+                </div>
+                <span id="helpBlock" class="help-block">If target is unresolved, reload page and enter coordinates manually</span>
+            </div>
+
+
+        </div>
+        
+        <br>
+
+        <hr class="col-md-12">
+
         <div class='form-group'>
             
             <label for='mag' class="col-sm-2 control-label">Stellar Parameters</label>

--- a/exoctk/exoctk_app/templates/limb_darkening.html
+++ b/exoctk/exoctk_app/templates/limb_darkening.html
@@ -202,8 +202,7 @@
                         <div class="input-group">
                             <input class="btn btn-success" type="submit" name="submit" value="Retrieve Parameters"/>
                         </div>
-                        <span id="helpBlock" class="help-block">Enter parameters manually if no target name provided</span>
-
+                        <span id="helpBlock" class="help-block"><b>Retrieve parameters from ExoMAST. Fields below must be populated prior to submission!</b></span>
                         <br>
                         
                         
@@ -239,7 +238,11 @@
                           <input id='mu_min' type="text" class='form-control' name="mu_min" size="10" rows="1" value="0.1" placeholder="0 - 1"/>
                           <div class="input-group-addon" style='width:60px'></div>
                         </div>
-                        <span id="helpBlock" class="help-block">The minimum angle to consider when fitting the LD profile</span>
+                        <span id="helpBlock" class="help-block">The minimum angle to consider when fitting the LD profile (Default=0.1)</span>
+                       
+                        <br>
+
+                        <a href="{{limbVars.get('target_url')}}">Visit ExoMAST for more Information on this target.</a>
                     </div>
                 </div>
                 

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -516,20 +516,22 @@ def get_canonical_name(target_name):
     
     return canonical_name
 
-def get_target_data(target_name):
+def get_target_data(target_name, request_url=False):
     '''Send request to exomast restful api for target information.
         
         Parameters
         ----------
         target_name : string
             The name of the target transit. 
-
+        request_url: bool
+            bool to return exomast request url.
+        
         Returns
         -------
-        period : float
-            The period of the transit in days. 
-        transitDur : float
-            The duration of the transit in hours. 
+        target_data: json:
+            json object with target data.
+        target_url: string
+            url for data returned from exoMAST. 
 
     '''
 
@@ -548,4 +550,8 @@ def get_target_data(target_name):
     # Temporary... Need to write a parser to select catalog
     target_data = target_data[0]
     
-    return target_data
+    if request_url:
+        url = 'https://exo.mast.stsci.edu/exomast_planet.html?planet={}'.format(re.sub(r'\W+', '', canonical_name))
+        return target_data, url
+    else:
+        return target_data


### PR DESCRIPTION
Currently exomast dev is passing the target name as a url parameter. So when this tool is ready, we will be able to get all of the information from exoctk's tab in exomast. Need to also write test case when `transit_duration` is undefined because as of right now I have to type cast it to a float to calculate the observation duration and it can be value `null` which crashes the app.