### PR TITLE
fixed the nircam option for visibility calc

### DIFF
--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -437,7 +437,7 @@ def contam_visibility():
 
             # Make plot
             title = form.targname.data or ', '.join([form.ra.data, form.dec.data])
-            pG, pB, dates, vis_plot, table = vpa.using_gtvt(str(form.ra.data), str(form.dec.data), form.inst.data)
+            pG, pB, dates, vis_plot, table = vpa.using_gtvt(str(form.ra.data), str(form.dec.data), form.inst.data.split(' ')[0])
 
             # Make output table
             vers = '0.3'


### PR DESCRIPTION
this fixes a bug in the NIRCam option for the Contam Overlap tool

explanation: 
because NIRCam has 2 form options, the input parameter`form.inst.data` will return `NIRCam F444W` or `NIRCam F322W2`. this breaks the function, because it just wants `NIRCam` without the filter option. so I just split the string and pulled the `NIRCam` portion out of it 