### PR TITLE
Hot fix for groups and integrations.

### DIFF
--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -280,7 +280,7 @@ def groups_integrations():
         except TypeError:
             trans_dur = request.args.get('transit_duration')
             if trans_dur == None:
-                form.obs_duration.data = trans_dur
+                pass
             else:
                 err = 'The Transit Duration from ExoMAST experienced some issues. Try a different spelling or source.'
                 return render_template('groups_integrations_error.html', err=err)

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -272,11 +272,18 @@ def groups_integrations():
 
         # According to Kevin the obs_dur = 3*trans_dur+1 hours
         # transit_dur is in days from exomast, convert first.
-        trans_dur = float(request.args.get('transit_duration'))
-        trans_dur *= u.day.to(u.hour)
-        obs_dur = 3*trans_dur + 1
-        form.obs_duration.data = obs_dur
-        
+        try:
+            trans_dur = float(request.args.get('transit_duration'))
+            trans_dur *= u.day.to(u.hour)
+            obs_dur = 3*trans_dur + 1
+            form.obs_duration.data = obs_dur
+        except TypeError:
+            trans_dur = request.args.get('transit_duration')
+            if trans_dur == None:
+                form.obs_duration.data = trans_dur
+            else:
+                err = 'The Transit Duration from ExoMAST experienced some issues. Try a different spelling or source.'
+                return render_template('groups_integrations_error.html', err=err)
         return render_template('groups_integrations.html', form=form, sat_data=sat_data)
         
     # Reload page with stellar data from ExoMAST

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -337,7 +337,7 @@ def groups_integrations():
                   'mag': form.kmag.data,
                   'obs_time': form.obs_duration.data,
                   'sat_max': form.sat_max.data,
-                  'sat_mode': form.sat_mode,
+                  'sat_mode': form.sat_mode.data,
                   'time_unit': form.time_unit.data,
                   'band': 'K',
                   'mod': form.mod.data,
@@ -359,7 +359,6 @@ def groups_integrations():
 
         # Run the calculation
         results = perform_calculation(params)
-
         if type(results) == dict:
             results_dict = results
             one_group_error = ""

--- a/exoctk/exoctk_app/form_validation.py
+++ b/exoctk/exoctk_app/form_validation.py
@@ -82,7 +82,9 @@ class GroupsIntsForm(BaseForm):
     calculate_submit = SubmitField('Calculate Groups and Integrations')
 
     # Stellar Parameters
-    kmag = DecimalField('kmag', default=10.5, validators=[InputRequired('A K-band magnitude is required!')])
+    kmag = DecimalField('kmag', default=10.5, validators=[InputRequired('A
+        K-band magnitude is required!'), NumberRange(min=5.1, max=11.9
+            message='K-band mag must be between 5-12, non-inclusive.')])
     obs_duration = DecimalField('obs_duration', default=3, validators=[InputRequired('An observation duration is required!'), NumberRange(min=0, message='Observation duration must be a positive number')])
     time_unit = SelectField('time_unit', default='hour', choices=[('hour', 'hours'), ('day', 'days')])
     models = [('a0i', 'A0I 9750 2.0'), ('aov', 'A0V 9500 2.0'), ('a1v', 'A1V 9250 4.0'), ('a5i', 'A5I 8500 2.0'), ('a3v', 'A3V 8250 4.0'), ('a5v', 'A5V 8250 4.0'), ('f0i', 'F0I 7750 2.0'), ('f0v', 'F0V 7250 1.5'), ('f5i', 'F5I 7000 4.0'), ('f2v', 'F2V 7000 4.0'), ('f5v', 'F5V 6500 4.0'), ('f8v', 'F8V 6250 4.5'), ('g0v', 'G0V 6000 4.5'), ('g0iii', 'G0III 5750 3.0'), ('g2v', 'G2V 5750 4.5'), ('g5v', 'G5V 5750 4.5'), ('g0i', 'G0I 5500 1.5'), ('g8v', 'G8V 5500 4.5'), ('g5iii', 'G5III 5250 2.5'), ('g5i', 'G5I 4740 1.0'), ('k0v', 'K0V 5250 4.5'), ('k0iii', 'K0III 4750 2.0'), ('k2v', 'K2V 4750 4.5'), ('k0i', 'K0I 4500 1.0'), ('k5v', 'K5V 4250 1.5'), ('k5iii', 'K5III 4000 1.5'), ('k7v', 'K7V 4000 4.5'), ('k5i', 'K5I 3750 0.5'), ('m0i', 'M0I 3750 0.0'), ('m0iii', 'M0III 3750 1.5'), ('m0v', 'M0V 3750 4.5'), ('m2i', 'M2I 3500 0.0'), ('m2v', 'M2V 3500 4.5'), ('m5v', 'M5V 3500 5.0')]

--- a/exoctk/exoctk_app/form_validation.py
+++ b/exoctk/exoctk_app/form_validation.py
@@ -82,9 +82,7 @@ class GroupsIntsForm(BaseForm):
     calculate_submit = SubmitField('Calculate Groups and Integrations')
 
     # Stellar Parameters
-    kmag = DecimalField('kmag', default=10.5, validators=[InputRequired('A
-        K-band magnitude is required!'), NumberRange(min=5.1, max=11.9
-            message='K-band mag must be between 5-12, non-inclusive.')])
+    kmag = DecimalField('kmag', default=10.5, validators=[InputRequired('A K-band magnitude is required!'), NumberRange(min=5.1, max=11.9, message='K-band mag must be between 5-12, non-inclusive.')])
     obs_duration = DecimalField('obs_duration', default=3, validators=[InputRequired('An observation duration is required!'), NumberRange(min=0, message='Observation duration must be a positive number')])
     time_unit = SelectField('time_unit', default='hour', choices=[('hour', 'hours'), ('day', 'days')])
     models = [('a0i', 'A0I 9750 2.0'), ('aov', 'A0V 9500 2.0'), ('a1v', 'A1V 9250 4.0'), ('a5i', 'A5I 8500 2.0'), ('a3v', 'A3V 8250 4.0'), ('a5v', 'A5V 8250 4.0'), ('f0i', 'F0I 7750 2.0'), ('f0v', 'F0V 7250 1.5'), ('f5i', 'F5I 7000 4.0'), ('f2v', 'F2V 7000 4.0'), ('f5v', 'F5V 6500 4.0'), ('f8v', 'F8V 6250 4.5'), ('g0v', 'G0V 6000 4.5'), ('g0iii', 'G0III 5750 3.0'), ('g2v', 'G2V 5750 4.5'), ('g5v', 'G5V 5750 4.5'), ('g0i', 'G0I 5500 1.5'), ('g8v', 'G8V 5500 4.5'), ('g5iii', 'G5III 5250 2.5'), ('g5i', 'G5I 4740 1.0'), ('k0v', 'K0V 5250 4.5'), ('k0iii', 'K0III 4750 2.0'), ('k2v', 'K2V 4750 4.5'), ('k0i', 'K0I 4500 1.0'), ('k5v', 'K5V 4250 1.5'), ('k5iii', 'K5III 4000 1.5'), ('k7v', 'K7V 4000 4.5'), ('k5i', 'K5I 3750 0.5'), ('m0i', 'M0I 3750 0.0'), ('m0iii', 'M0III 3750 1.5'), ('m0v', 'M0V 3750 4.5'), ('m2i', 'M2I 3500 0.0'), ('m2v', 'M2V 3500 4.5'), ('m5v', 'M5V 3500 5.0')]

--- a/exoctk/exoctk_app/form_validation.py
+++ b/exoctk/exoctk_app/form_validation.py
@@ -115,8 +115,8 @@ class GroupsIntsForm(BaseForm):
     nircam_subarray_ta = SelectField('nircam_subarray_ta', choices=[('sub32tats', 'SUB32TATS')])
 
     # Saturation
-    sat_mode = RadioField('modeldir', default='well', choices=[('counts', 'Counts'), ('well', 'Full well fraction')])
-    sat_max = DecimalField('sat_max', default=0.95, validators=[InputRequired('A saturation level is required!'), NumberRange(min=0.0, max=1.0, message='Saturation level must be between 0 and 1')])
+    sat_mode = RadioField('sat_mode', default='well', choices=[('counts', 'Counts'), ('well', 'Full well fraction')])
+    sat_max = DecimalField('sat_max', default=0.95, validators=[InputRequired('A saturation level is required!'), NumberRange(min=0.0, message='Saturation level must be positive.')])
 
 
 class ContamVisForm(BaseForm):

--- a/exoctk/exoctk_app/templates/index.html
+++ b/exoctk/exoctk_app/templates/index.html
@@ -15,7 +15,8 @@
                         most useful tools for observation planning, forward
                         modeling, data reduction, limb darkening, light curve
                         fitting, and retrievals. The full version of ExoCTK is
-                        available through <a href="https://github.com/ExoCTK/exoctk">GitHub.</p>
+                        available through <a
+                         href="https://github.com/ExoCTK/exoctk">GitHub.</a></p>
                     </div>
                 </div>
                 <hr class="col-md-12">

--- a/exoctk/groups_integrations/groups_integrations.py
+++ b/exoctk/groups_integrations/groups_integrations.py
@@ -254,7 +254,7 @@ def convert_sat(sat_max, sat_mode, ins, infile, ta=False):
 
     ins_dict = dat['fullwell'] 
     
-    if sat_max <= 1:
+    if sat_mode == 'well':
         sat_max = float(sat_max)*float(ins_dict[ins])
     
     if ta:

--- a/exoctk/groups_integrations/groups_integrations.py
+++ b/exoctk/groups_integrations/groups_integrations.py
@@ -254,8 +254,8 @@ def convert_sat(sat_max, sat_mode, ins, infile, ta=False):
 
     ins_dict = dat['fullwell'] 
     
-    if sat_mode == 'well':
-        sat_max = sat_max*ins_dict[ins]
+    if sat_max <= 1:
+        sat_max = float(sat_max)*float(ins_dict[ins])
     
     if ta:
         sat_max = ins_dict[ins]


### PR DESCRIPTION
This is a not particularly elegant fix for #282.

It looks like for some reason when you open the Groups and Integrations Calculator, it's trying to form submit right then and there. (I would bet this is true for all/most of the other API wrapped forms) but this one needs to immediately do math operations on the at this time empty inputs, and the attempted type casting of nothing throws an error.

My fix for now is to catch this error, make sure it's a nonetype, and give it a chance to chill and see if some more input gets thrown that way. For the case that (I'm not sure exists but 🤷‍♂ ) I wrote a little custom message and rerouted it to the error template. 

@mfixstsci I would definitely like your input in case this has unforseen complications. 