### PR TITLE
Fixing unit bug

### DIFF
--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -300,7 +300,14 @@ def groups_integrations():
                 kmag = data.get('Kmag')
 
                 # Transit duration in exomast is in days, need it in hours
-                obs_time = data.get('transit_duration')*u.Unit(form.time_unit.data).to('hour')
+                if form.time_unit.data == 'day':
+                    obs_dur = data.get('transit_duration')
+                    form.obs_duration.data = obs_dur
+                else:
+                    trans_dur = data.get('transit_duration')
+                    trans_dur *= u.Unit('day').to('hour')
+                    obs_dur = 3*trans_dur + 1
+                    form.obs_duration.data = obs_dur
 
                 # Model guess
                 logg_targ = data.get('stellar_gravity') or 4.5
@@ -319,7 +326,6 @@ def groups_integrations():
                 # Set the form values
                 form.mod.data = mod_table[-1]['value']
                 form.kmag.data = kmag
-                form.obs_duration.data = obs_time
                 form.target_url.data = url
 
             except:

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -301,7 +301,8 @@ def groups_integrations():
 
                 # Transit duration in exomast is in days, need it in hours
                 if form.time_unit.data == 'day':
-                    obs_dur = data.get('transit_duration')
+                    trans_dur = data.get('transit_duration')
+                    obs_dur = 3*trans_dur + (1/24.) 
                     form.obs_duration.data = obs_dur
                 else:
                     trans_dur = data.get('transit_duration')

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -303,12 +303,11 @@ def groups_integrations():
                 if form.time_unit.data == 'day':
                     trans_dur = data.get('transit_duration')
                     obs_dur = 3*trans_dur + (1/24.) 
-                    form.obs_duration.data = obs_dur
                 else:
                     trans_dur = data.get('transit_duration')
                     trans_dur *= u.Unit('day').to('hour')
                     obs_dur = 3*trans_dur + 1
-                    form.obs_duration.data = obs_dur
+                    
 
                 # Model guess
                 logg_targ = data.get('stellar_gravity') or 4.5
@@ -327,6 +326,7 @@ def groups_integrations():
                 # Set the form values
                 form.mod.data = mod_table[-1]['value']
                 form.kmag.data = kmag
+                form.obs_duration.data = obs_dur
                 form.target_url.data = url
 
             except:


### PR DESCRIPTION
Had to replace form parsing with `if/else` block for now to make units for the groups and integrations to return correct observation times. If a user is coming from EXOMAST the conversion is done automatically, but if they want it in days, they will have to do it on their own or retrieve it from the url or EXOMAST.