### PR TITLE
Bokeh contam updates

### DIFF
--- a/exoctk/contam_visibility/visibilityPA.py
+++ b/exoctk/contam_visibility/visibilityPA.py
@@ -319,10 +319,10 @@ def using_gtvt(ra, dec, instrument, ephFileName=None, output='bokeh'):
                      title='Target Visibility with '+str(instrument))
 
     # Draw the curve and PA min/max patch
-    fig.line('date', 'panom', color=COLOR, legend='Nominal Aperture PA',\
-              source=SOURCE)
-    fig = fill_between(fig, gd, paMin, paMax, color=COLOR, fill_alpha=0.2,\
-                        line_alpha=0.1)
+    fig.circle('date', 'panom', color=COLOR, size=1, legend='Nominal Aperture PA',\
+              source=SOURCE, alpha=.5)
+    fig.circle('date', 'pamin', color=COLOR, size=1, source=SOURCE)
+    fig.circle('date', 'pamax', color=COLOR, size=1, source=SOURCE)
 
     # Adding HoverTool
     fig.add_tools(HoverTool(tooltips=TOOLTIPS,\

--- a/exoctk/contam_visibility/visibilityPA.py
+++ b/exoctk/contam_visibility/visibilityPA.py
@@ -16,7 +16,7 @@ import pkg_resources
 from astropy.table import Table
 from astropy.time import Time
 from bokeh.plotting import figure, ColumnDataSource
-from bokeh.models import HoverTool
+from bokeh.models import HoverTool, ranges
 from bokeh.models.widgets import Panel, Tabs
 import matplotlib.dates as mdates
 import numpy as np
@@ -332,6 +332,7 @@ def using_gtvt(ra, dec, instrument, ephFileName=None, output='bokeh'):
     # Plot formatting
     fig.xaxis.axis_label = 'Date'
     fig.yaxis.axis_label = 'Position Angle (degrees)'
+    fig.y_range = ranges.Range1d(0, 360)
 
     # Making the output table
     # Creating new lists w/o the NaN values
@@ -358,5 +359,4 @@ def using_gtvt(ra, dec, instrument, ephFileName=None, output='bokeh'):
     table = Table([v3minnan, v3maxnan, paMinnan, paMaxnan, paNomnan, gdnan, mjdnan],\
                   names=('#min_V3_PA', 'max_V3_PA','min_Aperture_PA',\
                          'max_Aperture_PA', 'nom_Aperture_PA', 'Gregorian', 'MJD'))
-
     return paMin, paMax, gd, fig, table


### PR DESCRIPTION
This puts in two small fixes for #285 .

It sets a default limit of the visibility plot to (0,360), as well as turns the line plots to sluggy little circle plots to get rid of the plotting over discontinuities. 