### PR TITLE
Flipped min and max duration time.

### DIFF
--- a/exoctk/exoctk_app/templates/groups_integrations_results.html
+++ b/exoctk/exoctk_app/templates/groups_integrations_results.html
@@ -73,8 +73,8 @@
                             <td>1 (fixed for target acquisition)</td>
                             <td>{{ results_dict['max_ta_groups'] }}</td>
                             <td>{{ results_dict['min_ta_groups'] }}</td>
-                            <td>{{ results_dict['t_duration_ta_min'] }}</td>
                             <td>{{ results_dict['t_duration_ta_max'] }}</td>
+                            <td>{{ results_dict['t_duration_ta_min'] }}</td>
                             <td>{{ results_dict['max_sat_ta'] }}</td>
                             <td>{{ results_dict['min_sat_ta'] }}</td>
                         </tr>


### PR DESCRIPTION
The max and min duration time are flipped. 

NOTE : it may be that they are flipped in the code, not in the template, but I'm switching them for now, and I will dig into the code at a later date. 