### PR TITLE
Remove EXOCTK_DATA from global scope

### DIFF
--- a/exoctk/contam_visibility/sossFieldSim.py
+++ b/exoctk/contam_visibility/sossFieldSim.py
@@ -8,9 +8,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.io import readsav
 
-IDLSAVE_PATH = os.path.join(os.environ.get('EXOCTK_DATA'),  'exoctk_contam')
-if IDLSAVE_PATH == '':
-    raise NameError("You need to have an exported 'EXOCTK_DATA' environment variable and data set up before we can continue.")
+from exoctk.utils import get_env_variables
+
+
+IDLSAVE_PATH = os.path.join(get_env_variables()['exoctk_data'],  'exoctk_contam')
 
 def sossFieldSim(ra, dec, binComp='', dimX=256):
     """Produce a SOSS field simulation for a target

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -34,7 +34,7 @@ from exoctk.contam_visibility import sossContamFig as cf
 from exoctk.forward_models.forward_models import fortney_grid, generic_grid
 from exoctk.groups_integrations.groups_integrations import perform_calculation
 from exoctk.limb_darkening import limb_darkening_fit as lf
-from exoctk.utils import find_closest, filter_table, get_target_data, get_canonical_name, FORTGRID_DIR, EXOCTKLOG_DIR, GENERICGRID_DIR
+from exoctk.utils import find_closest, filter_table, get_env_variables, get_target_data, get_canonical_name
 from exoctk.modelgrid import ModelGrid
 
 import log_exoctk
@@ -49,10 +49,10 @@ app_exoctk.config['SECRET_KEY'] = 'Thisisasecret!'
 
 
 # Load the database to log all form submissions
-if EXOCTKLOG_DIR is None:
+if get_env_variables()['exoctklog_dir'] is None:
     dbpath = ':memory:'
 else:
-    dbpath = os.path.realpath(os.path.join(EXOCTKLOG_DIR, 'exoctk_log.db'))
+    dbpath = os.path.realpath(os.path.join(get_env_variables()['exoctklog_dir'], 'exoctk_log.db'))
     if not os.path.isfile(dbpath):
         log_exoctk.create_db(dbpath)
 try:
@@ -302,12 +302,12 @@ def groups_integrations():
                 # Transit duration in exomast is in days, need it in hours
                 if form.time_unit.data == 'day':
                     trans_dur = data.get('transit_duration')
-                    obs_dur = 3*trans_dur + (1/24.) 
+                    obs_dur = 3*trans_dur + (1/24.)
                 else:
                     trans_dur = data.get('transit_duration')
                     trans_dur *= u.Unit('day').to('hour')
                     obs_dur = 3*trans_dur + 1
-                    
+
 
                 # Model guess
                 logg_targ = data.get('stellar_gravity') or 4.5
@@ -699,7 +699,7 @@ def groups_integrations_download():
 def fortney_download():
     """Download the fortney grid data"""
 
-    fortney_data = os.path.join(FORTGRID_DIR, 'fortney_grid.db')
+    fortney_data = os.path.join(get_env_variables()['fortgrid_dir'], 'fortney_grid.db')
     return send_file(fortney_data, attachment_filename='fortney_grid.db',
                      as_attachment=True)
 

--- a/exoctk/exoctk_app/form_validation.py
+++ b/exoctk/exoctk_app/form_validation.py
@@ -6,7 +6,7 @@ from wtforms.validators import InputRequired, Length, NumberRange, AnyOf
 from wtforms.widgets import ListWidget, CheckboxInput
 
 from exoctk.modelgrid import ModelGrid
-from exoctk.utils import MODELGRID_DIR, FILTERS, PROFILES
+from exoctk.utils import get_env_variables, FILTERS, PROFILES
 from svo_filters import svo
 
 
@@ -46,12 +46,13 @@ class FortneyModelForm(BaseForm):
 class LimbDarkeningForm(BaseForm):
     """Form validation for the limb_darkening tool"""
     # Model grid
-    default_modelgrid = os.path.join(MODELGRID_DIR, 'ATLAS9/')
+    modelgrid_dir = get_env_variables()['modelgrid_dir']
+    default_modelgrid = os.path.join(modelgrid_dir, 'ATLAS9/')
     mg = ModelGrid(default_modelgrid, resolution=500)
     teff_rng = mg.Teff_vals.min(), mg.Teff_vals.max()
     logg_rng = mg.logg_vals.min(), mg.logg_vals.max()
     feh_rng = mg.FeH_vals.min(), mg.FeH_vals.max()
-    modeldir = RadioField('modeldir', default=default_modelgrid, choices=[(os.path.join(MODELGRID_DIR, 'ACES/'), 'Phoenix ACES'), (os.path.join(MODELGRID_DIR, 'ATLAS9/'), 'Kurucz ATLAS9')], validators=[InputRequired('A model grid is required!')])
+    modeldir = RadioField('modeldir', default=default_modelgrid, choices=[(os.path.join(modelgrid_dir, 'ACES/'), 'Phoenix ACES'), (os.path.join(modelgrid_dir, 'ATLAS9/'), 'Kurucz ATLAS9')], validators=[InputRequired('A model grid is required!')])
 
     # Stellar parameters
     teff = DecimalField('teff', default=3500, validators=[InputRequired('An effective temperature is required!'), NumberRange(min=teff_rng[0], max=teff_rng[1], message='Effective temperature must be between {} and {}'.format(*teff_rng))])

--- a/exoctk/tests/test_atmospheric_retrievals.py
+++ b/exoctk/tests/test_atmospheric_retrievals.py
@@ -24,7 +24,7 @@ import pytest
 
 from ..atmospheric_retrievals.platon_wrapper import PlatonWrapper
 
-ON_TRAVIS = os.path.expanduser('~') == '/Users/travis'
+ON_TRAVIS = os.path.expanduser('~') in ['/Users/travis', '/home/travis']
 
 def initialize_platon_wrapper_object():
     """Return a ``PlatonWrapper`` object for use by the tests within

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -29,37 +29,6 @@ FILTERS = svo.filters()
 # Set the version
 VERSION = '0.2'
 
-# Get the location of EXOCTK_DATA environvment variable and check that it is valid
-EXOCTK_DATA = os.environ.get('EXOCTK_DATA')
-
-# If the variable is blank or doesn't exist
-ON_TRAVIS = os.path.expanduser('~') == '/home/travis' or os.path.expanduser('~') == '/Users/travis'
-if not ON_TRAVIS:
-    if not EXOCTK_DATA:
-        raise ValueError(
-            'The $EXOCTK_DATA environment variable is not set.  Please set the '
-            'value of this variable to point to the location of the ExoCTK data '
-            'download folder.  Users may retreive this folder by clicking the '
-            '"ExoCTK Data Download" button on the ExoCTK website.'
-        )
-
-    # If the variable exists but doesn't point to a real location
-    if not os.path.exists(EXOCTK_DATA):
-        raise FileNotFoundError(
-            'The $EXOCTK_DATA environment variable is set to a location that '
-            'cannot be accessed.')
-
-    # If the variable exists, points to a real location, but is missing contents
-    for item in ['modelgrid', 'fortney', 'exoctk_log', 'generic']:
-        if item not in [os.path.basename(item) for item in glob.glob(os.path.join(EXOCTK_DATA, '*'))]:
-            raise KeyError('Missing {}/ directory from {}'.format(item, EXOCTK_DATA))
-
-MODELGRID_DIR = os.path.join(EXOCTK_DATA, 'modelgrid/')
-FORTGRID_DIR = os.path.join(EXOCTK_DATA, 'fortney/')
-EXOCTKLOG_DIR = os.path.join(EXOCTK_DATA, 'exoctk_log/')
-GENERICGRID_DIR = os.path.join(EXOCTK_DATA, 'generic/')
-
-
 def color_gen(colormap='viridis', key=None, n=10):
     """Color generator for Bokeh plots
 
@@ -522,6 +491,51 @@ def get_canonical_name(target_name):
     canonical_name = planetnames['canonicalName']
 
     return canonical_name
+
+def get_env_variables():
+    """Returns a dictionary containing various environment variable
+    information.
+
+    Returns
+    -------
+    env_variables : dict
+        A dictionary containing various environment variable data
+    """
+
+    env_variables = {}
+
+    # Get the location of EXOCTK_DATA environvment variable and check that it is valid
+    env_variables['exoctk_data'] = os.environ.get('EXOCTK_DATA')
+
+    # If the variable is blank or doesn't exist
+    ON_TRAVIS = os.path.expanduser('~') == '/home/travis' or os.path.expanduser('~') == '/Users/travis'
+    if not ON_TRAVIS:
+        if not env_variables['exoctk_data']:
+            raise ValueError(
+                'The $EXOCTK_DATA environment variable is not set.  Please set the '
+                'value of this variable to point to the location of the ExoCTK data '
+                'download folder.  Users may retreive this folder by clicking the '
+                '"ExoCTK Data Download" button on the ExoCTK website.'
+            )
+
+        # If the variable exists but doesn't point to a real location
+        if not os.path.exists(env_variables['exoctk_data']):
+            raise FileNotFoundError(
+                'The $EXOCTK_DATA environment variable is set to a location that '
+                'cannot be accessed.')
+
+        # If the variable exists, points to a real location, but is missing contents
+        for item in ['modelgrid', 'fortney', 'exoctk_log', 'generic']:
+            if item not in [os.path.basename(item) for item in glob.glob(os.path.join(env_variables['exoctk_data'], '*'))]:
+                raise KeyError('Missing {}/ directory from {}'.format(item, env_variables['exoctk_data']))
+
+    env_variables['modelgrid_dir'] = os.path.join(env_variables['exoctk_data'], 'modelgrid/')
+    env_variables['fortgrid_dir'] = os.path.join(env_variables['exoctk_data'], 'fortney/')
+    env_variables['exoctklog_dir'] = os.path.join(env_variables['exoctk_data'], 'exoctk_log/')
+    env_variables['genericgrid_dir'] = os.path.join(env_variables['exoctk_data'], 'generic/')
+
+    return env_variables
+
 
 def get_target_data(target_name):
     """


### PR DESCRIPTION
This PR adds a new function `get_env_variables` that stores and returns the `EXOCTK_DATA` env variable and subsequent dependent env variables (e.g. `MODELGRID_DIR`) in a dictionary.  This function can then be called to retrieve these data when needed, instead of having it all in the global scope of `utils.py`.

Closes #298 