### PR TITLE
Update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,6 @@ To obtain the ``exoctk`` package with the necessary environment files, clone the
 
   git clone https://github.com/ExoCTK/exoctk.git
   cd exoctk
-  python setup.py [install|devlop]
 
 Obtain the ``exoctk`` Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -127,13 +127,7 @@ You must first have a working installation of ``anaconda`` or ``miniconda`` for 
 Obtain the ``exoctk`` Package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To obtain the ``exoctk`` package with the necessary environment files, you can either install the package via ``pip``:
-
-::
-
-  pip install exoctk
-
-or, clone the repository directly from GitHub:
+To obtain the ``exoctk`` package with the necessary environment files, clone the repository directly from GitHub:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -137,9 +137,13 @@ To obtain the ``exoctk`` package with the necessary environment files, clone the
 Obtain the ``exoctk`` Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The ``exoctk`` data package will be available through the MAST portal soon!
+Until then...
+
 To obtain the ``exoctk`` data, visit the `ExoCTK website <https://exoctk.stsci.edu/>`_ and navigate to the "ExoCTK Data Download" tab.
 This will start a download of a zipped package of all the data you need to run
-``exoctk``.
+``exoctk``. (Due to the large size of the data, the download may fail without a
+hard line internet connection.)
 
 Because it is a fairly hefty data download, you'll need to be thoughtful about
 how you unzip it.

--- a/README.rst
+++ b/README.rst
@@ -210,14 +210,8 @@ where again, ``<PYTHON_VERSION>`` is the version of python you are using (e.g. `
 Package Installation
 ~~~~~~~~~~~~~~~~~~~~
 
-In order to install the ``exoctk`` package within the newly-created ``conda`` environment, one must re-install the package, either via ``pip``:
-
-::
-
-  pip install exoctk
-
-
-or by running the `exoctk` setup script:
+In order to install the ``exoctk`` package within the newly-created ``conda``
+environment, run the `exoctk` setup script:
 
 ::
 


### PR DESCRIPTION
Upon having a new user test out our installation instructions (thank you @kjbrooks), it became clear that the order of our install instructions are a bit confusing, since one needs to obtain the package first to get the environment files, then install the environment, and then re-install the package.  This would be difficult to do via `pip` since `pip` usually installs packages to an obscure location, so modified the install instructions to ask users to clone directly from GitHub. 