### PR TITLE
Correction for observation duration for phase overlap

### DIFF
--- a/exoctk/phase_constraint_overlap/phase_constraint_overlap.py
+++ b/exoctk/phase_constraint_overlap/phase_constraint_overlap.py
@@ -69,7 +69,7 @@ def calculate_obsDur(transitDur):
         obsdur : float
             The duration of the observation in hours. '''
 
-    obsDur = np.min((6, 3*transitDur+1))
+    obsDur = np.max((6, 3*transitDur+1))
 
     return obsDur
 


### PR DESCRIPTION
Tool is supposed to pick the max value between `(6, 3*transitDur+1)` not the minimum.