### PR TITLE
Modified utils plus contam_visibility files so import works 

### DIFF
--- a/exoctk/contam_visibility/sossContamFig.py
+++ b/exoctk/contam_visibility/sossContamFig.py
@@ -12,7 +12,17 @@ import numpy as np
 
 from . import visibilityPA as vpa
 
-TRACES_PATH = os.path.join(os.environ.get('EXOCTK_DATA'),  'exoctk_contam', 'traces')
+EXOCTK_DATA = os.environ.get('EXOCTK_DATA')
+if not EXOCTK_DATA:
+    print('WARNING: The $EXOCTK_DATA environment variable is not set. Contamination overlap will not work. Please set the '
+          'value of this variable to point to the location of the exoctk_data '
+            'download folder.  Users may retreive this folder by clicking the '
+            '"ExoCTK Data Download" button on the ExoCTK website, or by using '
+            'the exoctk.utils.download_exoctk_data() function.'
+          )
+    TRACES_PATH = None
+else:
+    TRACES_PATH = os.path.join(EXOCTK_DATA,  'exoctk_contam', 'traces')
 
 disp_nircam = 0.001 # microns
 lam0_nircam322w2 = 2.369
@@ -41,6 +51,8 @@ def contam(cube, instrument, targetName='noName', paRange=[0, 360],
     plotPAmin, plotPAmax = paRange
 
     # start calculations
+    if not TRACES_PATH:
+        return None
     lam_file = os.path.join(TRACES_PATH, 'NIRISS', 'lambda_order1-2.txt')
     ypix, lamO1, lamO2 = np.loadtxt(lam_file, unpack=True)
 

--- a/exoctk/contam_visibility/sossFieldSim.py
+++ b/exoctk/contam_visibility/sossFieldSim.py
@@ -10,12 +10,17 @@ from scipy.io import readsav
 from astropy.io import fits
 from exoctk.utils import get_env_variables
 
-TRACES_PATH = os.path.join(os.environ.get('EXOCTK_DATA'),
-                           'exoctk_contam',
-                           'traces')
-if TRACES_PATH == '':
-    raise NameError("You need to have an exported 'EXOCTK_DATA' environment \
-                     variable and data set up before we can continue")
+EXOCTK_DATA = os.environ.get('EXOCTK_DATA')
+if not EXOCTK_DATA:
+    print('WARNING: The $EXOCTK_DATA environment variable is not set. Contamination overlap will not work. Please set the '
+          'value of this variable to point to the location of the exoctk_data '
+            'download folder.  Users may retreive this folder by clicking the '
+            '"ExoCTK Data Download" button on the ExoCTK website, or by using '
+            'the exoctk.utils.download_exoctk_data() function.'
+          )   
+    TRACES_PATH = None
+else:
+    TRACES_PATH = os.path.join(EXOCTK_DATA,  'exoctk_contam', 'traces')
 
 def sossFieldSim(ra, dec, binComp='', dimX=256):
     """ Produce a SOSS field simulation for a target.
@@ -660,4 +665,5 @@ def fieldSim(ra, dec, instrument, binComp=''):
 if __name__ == '__main__':
     ra, dec = "04 25 29.0162", "-30 36 01.603"  # Wasp 79
     #sossFieldSim(ra, dec)
-    fieldSim(ra, dec, instrument='NIRISS')
+    if EXOCTK_DATA:
+        fieldSim(ra, dec, instrument='NIRISS')

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -54,7 +54,7 @@ if not ON_TRAVIS_OR_RTD:
             if item not in [os.path.basename(item) for item in glob.glob(os.path.join(EXOCTK_DATA, '*'))]:
                 print(
                     'WARNING: Missing {}/ directory from {}. Please ensure that the ExoCTK data package has been '
-                    'downloaded. Users may retrieve this package by clicking the "ExoCTK Data Donwload" '
+                    'downloaded. Users may retrieve this package by clicking the "ExoCTK Data Download" '
                     'button on the ExoCTK website, or by using the exoctk.utils.download_exoctk_data() '
                     'function'.format(item, EXOCTK_DATA))
 

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -40,8 +40,7 @@ if not ON_TRAVIS_OR_RTD:
             'value of this variable to point to the location of the exoctk_data '
             'download folder.  Users may retreive this folder by clicking the '
             '"ExoCTK Data Download" button on the ExoCTK website, or by using '
-            'the exoctk.utils.download_exoctk_data() function.'
-        )
+            'the exoctk.utils.download_exoctk_data() function.')
     else:
         # If the variable exists but doesn't point to a real location
         if not os.path.exists(EXOCTK_DATA):
@@ -90,7 +89,8 @@ def download_exoctk_data(download_location=os.path.expanduser('~')):
         print('Data download failed.  Unable to create {}.  Please check permissions.')
 
     # URLs to download contents
-    urls = ['https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/exoctk_log.tar.gz',
+    urls = ['https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/exoctk_contam.tar.gz',
+            'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/exoctk_log.tar.gz',
             'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/groups_integrations.tar.gz',
             'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/fortney.tar.gz',
             'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/generic.tar.gz',

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -42,28 +42,28 @@ if not ON_TRAVIS_OR_RTD:
             '"ExoCTK Data Download" button on the ExoCTK website, or by using '
             'the exoctk.utils.download_exoctk_data() function.'
         )
-
-    # If the variable exists but doesn't point to a real location
-    if not os.path.exists(EXOCTK_DATA):
-        print(
-            'WARNING: The $EXOCTK_DATA environment variable is set to a location that '
-            'cannot be accessed.')
-
-    # If the variable exists, points to a real location, but is missing contents
-    for item in ['exoctk_contam', 'exoctk_log', 'fortney', 'generic', 'groups_integrations', 'modelgrid']:
-        if item not in [os.path.basename(item) for item in glob.glob(os.path.join(EXOCTK_DATA, '*'))]:
+    else:
+        # If the variable exists but doesn't point to a real location
+        if not os.path.exists(EXOCTK_DATA):
             print(
-                'WARNING: Missing {}/ directory from {}. Please ensure that the ExoCTK data package has been '
-                'downloaded. Users may retrieve this package by clicking the "ExoCTK Data Donwload" '
-                'button on the ExoCTK website, or by using the exoctk.utils.download_exoctk_data() '
-                'function'.format(item, EXOCTK_DATA))
+                'WARNING: The $EXOCTK_DATA environment variable is set to a location that '
+                'cannot be accessed.')
 
-EXOCTK_CONTAM_DIR = os.path.join(EXOCTK_DATA, 'exoctk_contam/')
-EXOCTKLOG_DIR = os.path.join(EXOCTK_DATA, 'exoctk_log/')
-FORTGRID_DIR = os.path.join(EXOCTK_DATA, 'fortney/')
-GENERICGRID_DIR = os.path.join(EXOCTK_DATA, 'generic/')
-GROUPS_INTEGRATIONS_DIR = os.path.join(EXOCTK_DATA, 'groups_integrations/')
-MODELGRID_DIR = os.path.join(EXOCTK_DATA, 'modelgrid/')
+        # If the variable exists, points to a real location, but is missing contents
+        for item in ['exoctk_contam', 'exoctk_log', 'fortney', 'generic', 'groups_integrations', 'modelgrid']:
+            if item not in [os.path.basename(item) for item in glob.glob(os.path.join(EXOCTK_DATA, '*'))]:
+                print(
+                    'WARNING: Missing {}/ directory from {}. Please ensure that the ExoCTK data package has been '
+                    'downloaded. Users may retrieve this package by clicking the "ExoCTK Data Donwload" '
+                    'button on the ExoCTK website, or by using the exoctk.utils.download_exoctk_data() '
+                    'function'.format(item, EXOCTK_DATA))
+
+        EXOCTK_CONTAM_DIR = os.path.join(EXOCTK_DATA, 'exoctk_contam/')
+        EXOCTKLOG_DIR = os.path.join(EXOCTK_DATA, 'exoctk_log/')
+        FORTGRID_DIR = os.path.join(EXOCTK_DATA, 'fortney/')
+        GENERICGRID_DIR = os.path.join(EXOCTK_DATA, 'generic/')
+        GROUPS_INTEGRATIONS_DIR = os.path.join(EXOCTK_DATA, 'groups_integrations/')
+        MODELGRID_DIR = os.path.join(EXOCTK_DATA, 'modelgrid/')
 
 
 def download_exoctk_data(download_location=os.path.expanduser('~')):


### PR DESCRIPTION
Playing around with a fresh installation of ExoCTK, found out that there was no way to use the new `exoctk.utils.download_exoctk_data()`, because when the `EXOCTK_DATA` environment is not set, `os.environ.get('EXOCTK_DATA')` is `None` by default which leads to some crashes. 

This PR fixes this behavior, so a fresh installation of ExoCTK without defining the `EXOCTK_DATA` environment (and thus, without even thinking of downloading the ExoCTK dataset) enables the user to import exoctk without the code crashing. It still warns the user that the environment has to be set several times to have full functionality.

Defining @bourque and @jaymedina to review this as they both worked on the imporvement of the `exoctk/utils.py` code to allow for the data to be downloaded via the `exoctk.utils.download_exoctk_data()` function.