### PR TITLE
updating docstrings: RA and Dec as str

### DIFF
--- a/exoctk/contam_visibility/visibilityPA.py
+++ b/exoctk/contam_visibility/visibilityPA.py
@@ -55,10 +55,10 @@ def checkVisPA(ra, dec, targetName=None, ephFileName=None, fig=None):
 
     Parameters
     ----------
-    ra: float
-        The RA of the target
-    dec: float
-        The Dec of the target
+    ra: str
+        The RA of the target in hh:mm:ss.s or dd:mm:ss.s or representing a float
+    dec: str
+        The Dec of the target in hh:mm:ss.s or dd:mm:ss.s or representing a float
     targetName: str
         The target name
     ephFileName: str
@@ -238,10 +238,10 @@ def using_gtvt(ra, dec, instrument, targetName='noName', ephFileName=None, outpu
 
     Parameters
     ----------
-    ra : float
-        The RA of the target (in degrees).
-    dec : float
-        The Dec of the target (in degrees).
+    ra : str
+        The RA of the target (in degrees) hh:mm:ss.s or dd:mm:ss.s or representing a float
+    dec : str
+        The Dec of the target (in degrees) hh:mm:ss.s or dd:mm:ss.s or representing a float
     instrument : str
         Name of the instrument. Can either be (case-sensitive):
         'NIRISS', 'NIRCam', 'MIRI', 'FGS', or 'NIRSpec'


### PR DESCRIPTION
RA and Dec are handled as strings by some functions, either in hh:mm:ss.s or dd:mm:ss.s format or representing a float. Updating documentation to match.

Found this while updating sanitizing input of MAST exo-mast web services that call this library. Similar updates may need to be made elsewhere in exoctk, but this is as far as I've looked.