### PR TITLE
Fix Fortney File Download Function

### DIFF
--- a/exoctk/exoctk_app/templates/fortney.html
+++ b/exoctk/exoctk_app/templates/fortney.html
@@ -154,7 +154,7 @@
 </div>
 
 <div>
-    <form action="/visib_result" method="post">
+    <form action="/fortney_result" method="post">
         <input type="hidden" name="data_file" value="{{ table_string }}" />
         <input class="btn btn-primary" type='submit' value='Save File'></p>
     </form>


### PR DESCRIPTION
Fixes #351. This pr fixes the data download function for the Fortney Models. Previously, the app was pointing to the `/visib_result` route which was causing a bad request error. Now it points to `/fortney_result`

Running locally test, copy and paste this example into the url bar:

http://0.0.0.0:5000/fortney?ptemp=2000.0&pchem=eqchem&cloud=0&pmass=10.4296&m_unit=M_jup&refrad=1.165&r_unit=R_jup&rstar=1.23&rstar_unit=R_sun

This should pull up the download dialog and save the file to your downloads folder. If you wish to plot the result I used the following code snippet below:

```
from astropy.io import ascii
import matplotlib.pyplot as plt

dat = ascii.read('~/Downloads/fortney.dat')
plt.plot(dat['col1'], dat['col2'])
plt.show()
```