### PR TITLE
Fix issues with bokeh v2.x

### DIFF
--- a/env/environment-3.6.yml
+++ b/env/environment-3.6.yml
@@ -3,8 +3,8 @@ channels:
   - defaults
   - http://ssb.stsci.edu/astroconda
 dependencies:
-  - astropy=4.0.2
-  - bokeh=2.2.1
+  - astropy=3.2.2
+  - bokeh=2.2.3
   - boto3
   - cython=0.29.17
   - docopt=0.6.2

--- a/env/environment-3.7.yml
+++ b/env/environment-3.7.yml
@@ -1,4 +1,4 @@
-name: exoctk-test-3.7
+name: exoctk-3.7
 channels:
   - defaults
   - http://ssb.stsci.edu/astroconda

--- a/env/environment-3.7.yml
+++ b/env/environment-3.7.yml
@@ -1,10 +1,10 @@
-name: exoctk-3.7
+name: exoctk-test-3.7
 channels:
   - defaults
   - http://ssb.stsci.edu/astroconda
 dependencies:
-  - astropy=4.0.2
-  - bokeh=2.1.1
+  - astropy=3.2.2
+  - bokeh=2.2.3
   - boto3
   - cython=0.29.17
   - docopt=0.6.2

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -9,7 +9,6 @@ import astropy.table as at
 from astropy.time import Time
 import astropy.units as u
 from bokeh.resources import INLINE
-from bokeh.util.string import encode_utf8
 from bokeh.embed import components
 import flask
 from flask import Flask, Response, send_from_directory
@@ -594,7 +593,7 @@ def fortney():
                                  temp=temp_out,
                                  table_string=table_string
                                  )
-    return encode_utf8(html)
+    return html
 
 
 @app_exoctk.route('/generic', methods=['GET', 'POST'])
@@ -626,7 +625,7 @@ def generic():
                                  js_resources=js_resources,
                                  css_resources=css_resources,
                                  )
-    return encode_utf8(html)
+    return html
 
 
 @app_exoctk.route('/fortney_result', methods=['POST'])

--- a/exoctk/forward_models/forward_models.py
+++ b/exoctk/forward_models/forward_models.py
@@ -25,7 +25,6 @@ from astropy.extern.six.moves import StringIO
 import astropy.table as at
 import astropy.units as u
 from bokeh.resources import INLINE
-from bokeh.util.string import encode_utf8
 from bokeh.embed import components
 from bokeh.models import Range1d
 from bokeh.models.widgets import Panel, Tabs

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,10 +1,10 @@
 asteval==0.9.16
-astropy==4.1
+astropy==3.2.2
 astroquery==0.4.1
 bandit==1.6.2
 batman-package==2.4.6
 bibtexparser==1.2.0
-bokeh==2.2.1
+bokeh==2.2.3
 boto3==1.16.9
 corner==2.1.0
 cython==0.29.21


### PR DESCRIPTION
This PR updates `bokeh` to version `2.2.3` and solves issues with the use of `bokeh.util.string.encode_utf8`