### PR TITLE
Added citation information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,9 +138,9 @@ If you use ExoCTK for work/research presented in a publication (whether directly
 
 ::
 
-  This research made use of the open source Python package exoctk, the Exoplanet Characterization Toolkit (Éspinoza et al, 2021).
+  This research made use of the open source Python package exoctk, the Exoplanet Characterization Toolkit (Espinoza et al, 2021).
 
-where (Éspinoza et al, 2021) is a citation of the Zenodo record, e.g.:
+where (Espinoza et al, 2021) is a citation of the Zenodo record, e.g.:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,18 @@
     :alt: ExoCTK Logo
     :scale: 10%
 
-|build-status| |docs|
-
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4556063.svg)](https://doi.org/10.5281/zenodo.4556063)
-
+.. image:: https://img.shields.io/github/release/ExoCTK/exoctk.svg
+    :target: https://github.com/ExoCTK/exoctk/releases/latest/
+.. image:: https://img.shields.io/pypi/l/Django.svg
+    :target: https://github.com/ExoCTK/exoctk/blob/master/LICENSE.rst
+.. image:: https://travis-ci.org/ExoCTK/exoctk.svg?branch=master
+    :target: https://travis-ci.org/ExoCTK/exoctk
+.. image:: https://readthedocs.org/projects/exoctk/badge/?version=latest
+    :target: https://exoctk.readthedocs.io/en/latest/?badge=latest
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4556063.svg
+   :target: https://doi.org/10.5281/zenodo.4556063
+.. image:: https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat
+   :target: http://www.stsci.edu
 
 
 Introduction

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. image:: /exoctk/data/images/ExoCTK_logo.png
     :alt: ExoCTK Logo
-    :scale: 10%
+    :scale: 5%
 
 .. image:: https://img.shields.io/github/release/ExoCTK/exoctk.svg
     :target: https://github.com/ExoCTK/exoctk/releases/latest/

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@
 
 |build-status| |docs|
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4556063.svg)](https://doi.org/10.5281/zenodo.4556063)
+
+
 
 Introduction
 ------------
@@ -120,7 +123,42 @@ Missing Dependencies?
 If you find that the `exoctk` `conda` is missing a required dependency, please feel free to `submit a GitHub Issue <https://github.com/ExoCTK/exoctk/issues>`_ detailing the problem.
 
 
+Citation
+--------
+
+If you use ExoCTK for work/research presented in a publication (whether directly, or as a dependency to another package), we recommend and encourage the following acknowledgment:
+
+::
+
+  This research made use of the open source Python package exoctk, the Exoplanet Characterization Toolkit (Éspinoza et al, 2021).
+
+where (Éspinoza et al, 2021) is a citation of the Zenodo record, e.g.:
+
+::
+
+  @software{nestor_espinoza_2021_4556063,
+    author       = {Néstor Espinoza and
+                    Matthew Bourque and
+                    Joseph Filippazzo and
+                    Michael Fox and
+                    Jules Fowler and
+                    Teagan King and
+                    Catherine Martlin and
+                    Jennifer Medina and
+                    Mees Fix and
+                    Kevin Stevenson and
+                    Jeff Valenti},
+    title        = {The Exoplanet Characterization Toolkit (ExoCTK)},
+    month        = feb,
+    year         = 2021,
+    publisher    = {Zenodo},
+    version      = {1.0.0},
+    doi          = {10.5281/zenodo.4556063},
+    url          = {https://doi.org/10.5281/zenodo.4556063}
+  }
+
+
 Want to stay up-to-date with our releases and updates?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------
 
 Subscribe to our newsletter by sending an email with a blank body and subject to ``exoctk-news-subscribe-request@maillist.stsci.edu`` from the email you want to enroll. You should then receive a confirmation email with instructions on how to confirm your subscription, please be sure to do so within 48 hours.


### PR DESCRIPTION
This PR adds citation information to the `README` file as part of the Tier 2 Software Standards for INS JWST tools.  Closes #443.

In this process, I created a Zenodo publication for the project, found here: https://zenodo.org/record/4556063/export/hx#.YDQepFlOmCM

Since I was changing `README`, I also took this opportunity to fix/add some badges.