### PR TITLE
Phase constraint hotfix + ready for development updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This file tracks all major changes in each `exoctk` release.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2021-07-09
+
+### Added
+
+- Sweep to update code to match PEP8 standards.
+- Extra authors on citation information to match current working DOI.
+
+### Fixed
+
+- Phase-constraint bug that didn't change `eccentricity` to `nan` when not found by the target resolver.
 
 ## [1.2.1] - 2021-06-09
 

--- a/README.rst
+++ b/README.rst
@@ -138,33 +138,37 @@ If you use ExoCTK for work/research presented in a publication (whether directly
 
 ::
 
-  This research made use of the open source Python package exoctk, the Exoplanet Characterization Toolkit (Espinoza et al, 2021).
+  This research made use of the open source Python package exoctk, the Exoplanet Characterization Toolkit (Bourque et al, 2021).
 
-where (Espinoza et al, 2021) is a citation of the Zenodo record, e.g.:
+where (Bourque et al, 2021) is a citation of the Zenodo record, e.g.:
 
 ::
 
-  @software{nestor_espinoza_2021_4556063,
-    author       = {Néstor Espinoza and
-                    Matthew Bourque and
-                    Joseph Filippazzo and
-                    Michael Fox and
-                    Jules Fowler and
-                    Teagan King and
-                    Catherine Martlin and
-                    Jennifer Medina and
-                    Mees Fix and
-                    Kevin Stevenson and
-                    Jeff Valenti},
-    title        = {The Exoplanet Characterization Toolkit (ExoCTK)},
-    month        = feb,
-    year         = 2021,
-    publisher    = {Zenodo},
-    version      = {1.0.0},
-    doi          = {10.5281/zenodo.4556063},
-    url          = {https://doi.org/10.5281/zenodo.4556063}
-  }
-
+    @software{matthew_bourque_2021_4556063,
+      author       = {Matthew Bourque and
+                      Néstor Espinoza and
+                      Joseph Filippazzo and
+                      Mees Fix and
+                      Teagan King and
+                      Catherine Martlin and
+                      Jennifer Medina and
+                      Natasha Batalha and
+                      Michael Fox and
+                      Jules Fowler and
+                      Jonathan Fraine and
+                      Matthew Hill and
+                      Nikole Lewis and
+                      Kevin Stevenson and
+                      Jeff Valenti and
+                      Hannah Wakeford},
+      title        = {The Exoplanet Characterization Toolkit (ExoCTK)},
+      month        = feb,
+      year         = 2021,
+      publisher    = {Zenodo},
+      version      = {1.0.0},
+      doi          = {10.5281/zenodo.4556063},
+      url          = {https://doi.org/10.5281/zenodo.4556063}
+    }
 
 Want to stay up-to-date with our releases and updates?
 ------------------------------------------------------

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -750,7 +750,7 @@ def phase_constraint(transit_type='primary'):
 
                 form.eccentricity.data = data.get('eccentricity')
                 if form.eccentricity.data is None:
-                    form.omega.data = np.nan
+                    form.eccentricity.data = np.nan
 
                 form.target_url.data = str(target_url)
 

--- a/exoctk/exoctk_app/templates/base.html
+++ b/exoctk/exoctk_app/templates/base.html
@@ -146,7 +146,7 @@
                         <div style="float:right; width:120px;text-align:center;">
                             <p>
                                 Running<br>
-                                <a href='https://github.com/ExoCTK/exoctk/releases/tag/v1.2.1'>exoctk v1.2.1</a>{{version|safe}}
+                                <a href='https://github.com/ExoCTK/exoctk/releases/tag/v1.2.2'>exoctk v1.2.2</a>{{version|safe}}
                             </p>
                             <p style='font-size:0.8em'>
                                 <a href='admin' style='color:#aaaaaa;'>Admin Area</a>

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ for root, _, files in os.walk("exoctk"):
 
 setup(
     name='exoctk',
-    version='1.2.1',
+    version='1.2.2',
     description='Observation reduction and planning tools for exoplanet science',
     packages=find_packages(
         ".",


### PR DESCRIPTION
Hi folks,

 Here comes a (hot) fix to a bug found by Nikolay Nikolov, in which the phase-constraint wouldn't work if eccentricity is not set manually to a number (or when not found by the target resolver). The problem was very simple: when the parameter is not found, it is populated by `None` by default in the web app forms. In theory we had solved this over a year ago, but apparently in the code I was double setting `omega` (and not `eccentricity`) as `np.nan` (which the web app form likes more than `None` values). I have now fixed that.

 In addition, I took the liberty of updating all the info in the `setup.py`, `CHANGELOG.md` and the web-app to match the next version release with this bug fixed (and Matthew's sweep of PEP8 on the code). I also took the liberty of updating the `Readme.rst` to match the DOI @bourque set up for us with the full list of co-authors to date of the package.

 This should be a relatively straightforward merge to `develop`!

N.