### PR TITLE
Fix NRS Visibility Plot

### DIFF
--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -452,10 +452,12 @@ def contam_visibility():
 
     if form.validate_on_submit() and (form.calculate_submit.data or form.calculate_contam_submit.data):
 
-        instrument = fs.APERTURES[form.inst.data]['inst']
+        if form.inst.data == "NIRSpec":
+            instrument = form.inst.data
+        else:
+            instrument = fs.APERTURES[form.inst.data]['inst']
 
         try:
-
             # Log the form inputs
             log_exoctk.log_form_input(request.form, 'contam_visibility', DB)
 


### PR DESCRIPTION
NRS does not have a dictionary key in `field_simulator.APERTURES`. This checks the value being passed from the form and if it is NRS, just make the instrument variable the string passed from the form. Data from the dictionary is only needed for calculating contamination.