### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "exoctk"
 description = "Exoplanet Characterization Toolkit"
 readme = "README.md"
+license-files = ["LICENSE.rst"]
 authors = [
   { name= "Matthew Bourque" },
   { name="Néstor Espinoza" },
@@ -77,10 +78,6 @@ docs = [
   "sphinx_rtd_theme",
   "stsci_rtd_theme",
 ]
-
-[project.license]
-file = "LICENSE"
-content-type = "text/plain"
 
 [project.urls]
 Repository = "https://github.com/ExoCTK/exoctk"


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))