### PR TITLE
Add security CI and harden flagged code paths

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,62 @@
+name: security
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/security.yml"
+      - "pyproject.toml"
+      - "setup.py"
+      - "exoctk/**/*.py"
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pip-audit
+
+      - name: Audit Python dependencies
+        run: python -m pip_audit . --progress-spinner off
+
+  bandit:
+    name: bandit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Bandit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "bandit[toml]"
+
+      - name: Scan Python source
+        run: python -m bandit -r exoctk -x exoctk/tests -ll

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/exoctk/contam_visibility/make_contam_traces.py
+++ b/exoctk/contam_visibility/make_contam_traces.py
@@ -210,8 +210,7 @@ def generate_pandeia_traces(min_teff=2800, max_teff=6000, increment=100, norm_ma
                 outdir = os.path.join(os.environ['EXOCTK_DATA'], 'exoctk_contam/traces')
 
             fullpath = os.path.join(outdir, name)
-            if not os.path.exists(fullpath):
-                os.system('mkdir {}'.format(fullpath))
+            os.makedirs(fullpath, exist_ok=True)
 
             # Save the file
             hdu0 = fits.PrimaryHDU()

--- a/exoctk/contam_visibility/source_catalog.py
+++ b/exoctk/contam_visibility/source_catalog.py
@@ -1589,6 +1589,16 @@ def query_GAIA_ptsrc_catalog(ra, dec, box_width):
     """
     logger = logging.getLogger('mirage.catalogs.create_catalog.query_GAIA_ptsrc_catalog')
 
+    try:
+        ra = float(ra)
+        dec = float(dec)
+        box_width = float(box_width)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            'ra, dec, and box_width must be numeric') from exc
+    if not np.all(np.isfinite((ra, dec, box_width))):
+        raise ValueError('ra, dec, and box_width must be finite')
+
     data = OrderedDict()
     data['gaia'] = OrderedDict()
     data['tmass'] = OrderedDict()
@@ -1599,11 +1609,11 @@ def query_GAIA_ptsrc_catalog(ra, dec, box_width):
     boxwidth = box_width/3600.
     data['gaia']['query'] = """SELECT * FROM gaiadr2.gaia_source AS gaia
                         WHERE 1=CONTAINS(POINT('ICRS',gaia.ra,gaia.dec), BOX('ICRS',{}, {}, {}, {}))
-                        """.format(ra, dec, boxwidth, boxwidth)
+                        """
 
     data['tmass']['query'] = """SELECT ra,dec,ph_qual,j_m,h_m,ks_m,designation FROM gaiadr1.tmass_original_valid AS tmass
                         WHERE 1=CONTAINS(POINT('ICRS',tmass.ra,tmass.dec), BOX('ICRS',{}, {}, {}, {}))
-                        """.format(ra, dec, boxwidth, boxwidth)
+                        """
 
     data['tmass_crossmatch']['query'] = """SELECT field.ra,field.dec,field.designation,tmass.designation from
             (SELECT gaia.*
@@ -1614,11 +1624,11 @@ def query_GAIA_ptsrc_catalog(ra, dec, box_width):
                 ON field.source_id = xmatch.source_id
             INNER JOIN gaiadr1.tmass_original_valid AS tmass
                 ON tmass.tmass_oid = xmatch.tmass_oid
-        """.format(ra, dec, boxwidth, boxwidth)
+        """
 
     data['wise']['query'] = """SELECT ra,dec,ph_qual,w1mpro,w2mpro,w3mpro,w4mpro,designation FROM gaiadr1.allwise_original_valid AS wise
                         WHERE 1=CONTAINS(POINT('ICRS',wise.ra,wise.dec), BOX('ICRS',{}, {}, {}, {}))
-                        """.format(ra, dec, boxwidth, boxwidth)
+                        """
 
     data['wise_crossmatch']['query'] = """SELECT field.ra,field.dec,field.designation,allwise.designation from
             (SELECT gaia.*
@@ -1629,7 +1639,11 @@ def query_GAIA_ptsrc_catalog(ra, dec, box_width):
                 ON field.source_id = xmatch.source_id
             INNER JOIN gaiadr1.allwise_original_valid AS allwise
                 ON allwise.designation = xmatch.original_ext_source_id
-        """.format(ra, dec, boxwidth, boxwidth)
+        """
+
+    for catalog in data.values():
+        catalog['query'] = catalog['query'].format(
+            ra, dec, boxwidth, boxwidth)
 
     outvalues = {}
     logger.info('Searching the GAIA DR2 catalog')

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -802,10 +802,8 @@ def contam_visibility():
                 os.environ['SHARED_DATA_DIR'], f'{task_uuid}_stars.pickle'
             )
             print(f"Loading {stars_file}")
-            with open(stars_file, "rb") as f:
-                stars = pickle.load(f)
+            stars = _load_and_remove_pickle(stars_file)
             print("Loaded stars")
-            os.remove(stars_file)
 
             # Add companion
             try:

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -425,7 +425,9 @@ def _load_and_remove_pickle(filename):
     """Load a complete worker artifact, then remove it after a safe read."""
 
     with open(filename, "rb") as f:
-        value = pickle.load(f)
+        # The paired Celery task creates this server-named artifact in the
+        # private worker volume; website users cannot supply its path or data.
+        value = pickle.load(f)  # nosec B301
     os.remove(filename)
     return value
 

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -1350,4 +1350,6 @@ if __name__ == '__main__':
     app_exoctk.logger.handlers = gunicorn_logger.handlers
     app_exoctk.logger.setLevel(gunicorn_logger.level)
     port = int(os.environ.get('PORT', 5000))
-    app_exoctk.run(host='0.0.0.0', port=port)
+    # The container must listen on every container interface so Docker can
+    # publish this service through its explicitly configured host port.
+    app_exoctk.run(host='0.0.0.0', port=port)  # nosec B104

--- a/exoctk/exoctk_app/templates/base.html
+++ b/exoctk/exoctk_app/templates/base.html
@@ -148,9 +148,6 @@
                                 Running<br>
                                 <a href='https://github.com/ExoCTK/exoctk/releases/tag/v1.2.6'>exoctk v1.2.6</a>{{version|safe}}
                             </p>
-                            <p style='font-size:0.8em'>
-                                <a href='admin' style='color:#aaaaaa;'>Admin Area</a>
-                            </p>
                         </div>
                     </div>
                 </div>

--- a/exoctk/log_exoctk.py
+++ b/exoctk/log_exoctk.py
@@ -150,8 +150,8 @@ def log_form_input(form_dict, table, database):
         The dictionary of form inputs
     table : str
         The table name to INSERT on
-    database : ``sqlite.connection.cursor`` obj
-        The database cursor object
+    database : ``sqlite3.Connection`` or ``sqlite3.Cursor``
+        The database connection or cursor used to insert the record.
     """
     table = _validate_sql_identifier(table)
 
@@ -193,8 +193,8 @@ def view_log(database, table, limit=50):
 
     Parameters
     ----------
-    database : str or ``sqlite3.connection.cursor`` obj
-        The database cursor object
+    database : str, ``sqlite3.Connection``, or ``sqlite3.Cursor``
+        The database path, connection, or cursor used to read the records.
     table : str
         The table name
     limit : int
@@ -217,10 +217,13 @@ def view_log(database, table, limit=50):
 
     if isinstance(database, str):
         DB = load_db(database)
+    elif isinstance(database, sqlite3.Connection):
+        DB = database.cursor()
     elif isinstance(database, sqlite3.Cursor):
         DB = database
     else:
-        print("Please enter the path to a .db file or a sqlite.Cursor object.")
+        raise TypeError(
+            'database must be a path, sqlite3.Connection, or sqlite3.Cursor')
 
     # Query the database
     query = f'PRAGMA table_info("{table}")'

--- a/exoctk/log_exoctk.py
+++ b/exoctk/log_exoctk.py
@@ -28,11 +28,24 @@ Dependencies
 
 import datetime
 import os
+import re
 
 import astropy.table as at
 import numpy as np
 from pathlib import Path
 import sqlite3
+
+
+SQL_IDENTIFIER = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+
+def _validate_sql_identifier(identifier):
+    """Return a safe SQL identifier or raise ``ValueError``."""
+
+    if (not isinstance(identifier, str) or
+            SQL_IDENTIFIER.fullmatch(identifier) is None):
+        raise ValueError(f'Invalid SQL identifier: {identifier!r}')
+    return identifier
 
 
 def create_db(dbpath, overwrite=True):
@@ -140,10 +153,13 @@ def log_form_input(form_dict, table, database):
     database : ``sqlite.connection.cursor`` obj
         The database cursor object
     """
+    table = _validate_sql_identifier(table)
+
     try:
 
         # Get the column names
-        colnames = np.array(database.execute("PRAGMA table_info('{}')".format(table)).fetchall()).T[1]
+        query = f'PRAGMA table_info("{table}")'
+        colnames = np.array(database.execute(query).fetchall()).T[1]
 
         # Convert hyphens to underscores and leading numerics to letters for db column names
         inpt = {k.replace('-', '_').replace('3', 'three').replace('4', 'four'): v for k, v in form_dict.items()}
@@ -152,9 +168,14 @@ def log_form_input(form_dict, table, database):
         inpt['date'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
 
         # Insert the form values that are valid column names
-        cols = [col for col in inpt.keys() if col in colnames]
+        cols = [_validate_sql_identifier(col)
+                for col in inpt.keys() if col in colnames]
         vals = [str(inpt.get(col, 'none')) for col in cols]
-        qry = "Insert Into {} ({}) Values ({})".format(table, ', '.join(cols), ', '.join('?' * len(cols)))
+        quoted_cols = ', '.join(f'"{col}"' for col in cols)
+        placeholders = ', '.join('?' * len(cols))
+        # Table and column identifiers have passed strict validation.
+        qry = (f'INSERT INTO "{table}" ({quoted_cols}) '  # nosec B608
+               f'VALUES ({placeholders})')
         database.execute(qry, vals)
 
     except Exception as e:
@@ -186,6 +207,14 @@ def view_log(database, table, limit=50):
 
     """
 
+    table = _validate_sql_identifier(table)
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError) as exc:
+        raise ValueError('limit must be a nonnegative integer') from exc
+    if limit < 0:
+        raise ValueError('limit must be a nonnegative integer')
+
     if isinstance(database, str):
         DB = load_db(database)
     elif isinstance(database, sqlite3.Cursor):
@@ -194,8 +223,11 @@ def view_log(database, table, limit=50):
         print("Please enter the path to a .db file or a sqlite.Cursor object.")
 
     # Query the database
-    colnames = np.array(DB.execute("PRAGMA table_info('{}')".format(table)).fetchall()).T[1]
-    results = DB.execute("SELECT * FROM {} LIMIT {}".format(table, limit)).fetchall()
+    query = f'PRAGMA table_info("{table}")'
+    colnames = np.array(DB.execute(query).fetchall()).T[1]
+    # The table is a validated identifier and the row limit remains bound.
+    query = f'SELECT * FROM "{table}" LIMIT ?'  # nosec B608
+    results = DB.execute(query, (limit,)).fetchall()
 
     # Empty table
     table = at.Table(names=colnames, dtype=['O'] * len(colnames))

--- a/exoctk/modelgrid.py
+++ b/exoctk/modelgrid.py
@@ -204,12 +204,12 @@ class ModelGrid(object):
 
                 # Make sure the model_grid.path matches the given model_directory
                 if os.path.dirname(file) != os.path.realpath(model_grid['path']):
-                    _ = os.system('rm {}'.format(file))
+                    os.remove(file)
                     flx_file = file.replace('model_grid.p', 'model_grid_flux.hdf5')
 
                     # Delete flux file if it exists
                     if os.path.isfile(flx_file):
-                        _ = os.system('rm {}'.format(flx_file))
+                        os.remove(flx_file)
 
                     # Set model_grid to None so it regenerates it with the correct path
                     model_grid = None

--- a/exoctk/modelgrid.py
+++ b/exoctk/modelgrid.py
@@ -200,7 +200,11 @@ class ModelGrid(object):
             file = model_directory.replace('*', 'model_grid.p')
 
             if os.path.isfile(file):
-                model_grid = pickle.load(open(file, 'rb'))
+                # This cache is installed with or generated from the model
+                # files in the trusted ExoCTK data directory. The web app
+                # cannot populate it from a request or uploaded file.
+                with open(file, 'rb') as cache:
+                    model_grid = pickle.load(cache)  # nosec B301
 
                 # Make sure the model_grid.path matches the given model_directory
                 if os.path.dirname(file) != os.path.realpath(model_grid['path']):

--- a/exoctk/tests/test_contam_worker.py
+++ b/exoctk/tests/test_contam_worker.py
@@ -93,3 +93,15 @@ def test_atomic_pickle_removes_temporary_file_on_failure(
 
     assert not output.exists()
     assert not list(tmp_path.glob(".contam-*"))
+
+
+def test_load_and_remove_pickle(tmp_path):
+    """A successfully loaded worker artifact is removed from disk."""
+
+    artifact = tmp_path / "result.pickle"
+    expected = {"result": [1, 2, 3]}
+    with artifact.open("wb") as f:
+        pickle.dump(expected, f)
+
+    assert app_exoctk._load_and_remove_pickle(str(artifact)) == expected
+    assert not artifact.exists()

--- a/exoctk/tests/test_gaia_tap.py
+++ b/exoctk/tests/test_gaia_tap.py
@@ -18,6 +18,7 @@ from exoctk.contam_visibility.field_simulator import (
     _target_source_index,
     calculate_current_coordinates,
 )
+from exoctk.contam_visibility import source_catalog
 
 
 CENTER = SkyCoord(10. * u.deg, 20. * u.deg)
@@ -73,6 +74,46 @@ def test_endpoint_native_query_construction(index, fragments):
 
     assert 'SELECT *' not in query
     assert all(fragment in query for fragment in fragments)
+
+
+def test_legacy_catalog_queries_coerce_numeric_inputs(monkeypatch):
+    """Legacy ADQL interpolation accepts only numeric coordinates and width."""
+
+    queries = []
+
+    class Job:
+        @staticmethod
+        def get_results():
+            return Table()
+
+    def launch_job(query, dump_to_file=False):
+        queries.append(query)
+        return Job()
+
+    monkeypatch.setattr(source_catalog.Gaia, 'launch_job', launch_job)
+
+    source_catalog.query_GAIA_ptsrc_catalog('10.5', '-20.25', '60')
+
+    assert len(queries) == 5
+    assert all('10.5, -20.25' in query for query in queries)
+    assert all('0.016666666666666666' in query for query in queries)
+
+
+@pytest.mark.parametrize(('ra', 'dec', 'box_width'), [
+    ('0); DROP TABLE gaiadr2.gaia_source', 20., 60.),
+    (10., '20 OR 1=1', 60.),
+    (10., 20., '60); SELECT * FROM tap_schema.tables'),
+])
+def test_legacy_catalog_queries_reject_nonnumeric_inputs(
+        monkeypatch, ra, dec, box_width):
+    """Nonnumeric values cannot become part of legacy ADQL queries."""
+
+    monkeypatch.setattr(
+        source_catalog.Gaia, 'launch_job',
+        lambda *args, **kwargs: pytest.fail('query should not be submitted'))
+
+    with pytest.raises(ValueError, match='must be numeric'):
+        source_catalog.query_GAIA_ptsrc_catalog(ra, dec, box_width)
 
 
 @pytest.mark.parametrize('endpoint', GAIA_TAP_ENDPOINTS)

--- a/exoctk/tests/test_log_exoctk.py
+++ b/exoctk/tests/test_log_exoctk.py
@@ -116,6 +116,26 @@ def test_view_log(tmp_path):
     os.remove(db_path)
 
 
+def test_view_log_accepts_connection(tmp_path):
+    """A SQLite connection can be used directly to inspect a log."""
+
+    db_path = str(tmp_path / 'test.db')
+    log_exoctk.create_db(db_path)
+    connection = sqlite3.connect(db_path)
+
+    table = log_exoctk.view_log(connection, 'groups_integrations')
+
+    assert len(table) == 0
+    connection.close()
+
+
+def test_view_log_rejects_unsupported_database():
+    """Unsupported database objects raise a clear error."""
+
+    with pytest.raises(TypeError, match='database must be'):
+        log_exoctk.view_log(object(), 'groups_integrations')
+
+
 @pytest.mark.parametrize('table', [
     'groups-integrations',
     '1groups_integrations',

--- a/exoctk/tests/test_log_exoctk.py
+++ b/exoctk/tests/test_log_exoctk.py
@@ -18,9 +18,10 @@ Use
 """
 
 import os
+import sqlite3
 
 import astropy
-import sqlite3
+import pytest
 
 from exoctk import log_exoctk
 
@@ -113,3 +114,38 @@ def test_view_log(tmp_path):
 
     # Remove the database
     os.remove(db_path)
+
+
+@pytest.mark.parametrize('table', [
+    'groups-integrations',
+    '1groups_integrations',
+    'groups_integrations; DROP TABLE groups_integrations',
+])
+def test_logging_rejects_invalid_table_names(tmp_path, table):
+    """Dynamic SQL table names must be simple identifiers."""
+
+    db_path = str(tmp_path / 'test.db')
+    log_exoctk.create_db(db_path)
+    connection = sqlite3.connect(db_path)
+
+    with pytest.raises(ValueError, match='Invalid SQL identifier'):
+        log_exoctk.log_form_input({}, table, connection)
+    with pytest.raises(ValueError, match='Invalid SQL identifier'):
+        log_exoctk.view_log(connection.cursor(), table)
+
+    connection.close()
+
+
+@pytest.mark.parametrize('limit', [-1, '-1', '1; DROP TABLE generic'])
+def test_view_log_rejects_invalid_limits(tmp_path, limit):
+    """Log row limits must convert to nonnegative integers."""
+
+    db_path = str(tmp_path / 'test.db')
+    log_exoctk.create_db(db_path)
+    connection = sqlite3.connect(db_path)
+
+    with pytest.raises(ValueError, match='nonnegative integer'):
+        log_exoctk.view_log(
+            connection.cursor(), 'groups_integrations', limit=limit)
+
+    connection.close()

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -37,6 +37,7 @@ except TypeError:
 
 # Supported profiles
 PROFILES = ['linear', 'quadratic', 'square-root', 'logarithmic', 'exponential', '3-parameter', '4-parameter']
+REQUEST_TIMEOUT = 60
 
 # The ExoCTK data packages are distributed as versioned tar archives.  These
 # links are also used by the website test workflow.
@@ -434,7 +435,7 @@ def download_exoctk_data(tool='all', exoctk_data_dir=EXOCTK_DATA):
         download_paths.append(landing_path)
         print('({}/{}) Downloading data to {} from {}'.format(i + 1, len(archives), landing_path, url))
         try:
-            with requests.get(url, stream=True, timeout=60) as response:
+            with requests.get(url, stream=True, timeout=REQUEST_TIMEOUT) as response:
                 response.raise_for_status()
                 with open(landing_path, 'wb') as f:
                     for chunk in response.iter_content(chunk_size=2048):
@@ -590,30 +591,30 @@ def filter_table(table, **kwargs):
                 # Equality
                 if cond.startswith('='):
                     v = cond.replace('=', '')
-                    if v.replace('.', '', 1).isdigit():
-                        table = table[table[param] == eval(v)]
-                    else:
+                    try:
+                        table = table[table[param] == float(v)]
+                    except ValueError:
                         table = table[table[param] == v]
 
                 # Less than or equal
                 elif cond.startswith('<='):
                     v = cond.replace('<=', '')
-                    table = table[table[param] <= eval(v)]
+                    table = table[table[param] <= float(v)]
 
                 # Less than
                 elif cond.startswith('<'):
                     v = cond.replace('<', '')
-                    table = table[table[param] < eval(v)]
+                    table = table[table[param] < float(v)]
 
                 # Greater than or equal
                 elif cond.startswith('>='):
                     v = cond.replace('>=', '')
-                    table = table[table[param] >= eval(v)]
+                    table = table[table[param] >= float(v)]
 
                 # Greater than
                 elif cond.startswith('>'):
                     v = cond.replace('>', '')
-                    table = table[table[param] > eval(v)]
+                    table = table[table[param] > float(v)]
 
                 else:
                     raise ValueError("'{}' operator not valid.".format(cond))
@@ -681,7 +682,7 @@ def get_canonical_name(target_name):
     # Create params dict for url parsing. Easier than trying to format yourself.
     params = {"name": target_name}
 
-    r = requests.get(target_url, params=params)
+    r = requests.get(target_url, params=params, timeout=REQUEST_TIMEOUT)
     planetnames = r.json()
     canonical_name = planetnames['canonicalName']
 
@@ -751,7 +752,7 @@ def get_target_data(target_name):
 
     target_url = build_target_url(canonical_name)
 
-    r = requests.get(target_url)
+    r = requests.get(target_url, timeout=REQUEST_TIMEOUT)
 
     if r.status_code == 200:
         target_data = r.json()
@@ -989,7 +990,7 @@ def smooth(x, window_len=10, window='hanning'):
     if window == 'flat':
         w = np.ones(window_len, 'd')
     else:
-        w = eval('np.' + window + '(window_len)')
+        w = getattr(np, window)(window_len)
 
     y = np.convolve(w / w.sum(), s, mode='same')
 


### PR DESCRIPTION
## Summary

- Add a security workflow running Bandit and `pip-audit` for pull requests, weekly schedules, and manual dispatches.
- Pin third-party GitHub Actions to commit SHAs and run security checks on a supported Python version.
- Replace unsafe uses of `eval()` and shell commands with direct Python alternatives.
- Add explicit network timeouts.
- Validate dynamic SQLite identifiers and limits while continuing to parameterize values.
- Require finite numeric inputs before constructing legacy Gaia, 2MASS, and WISE ADQL queries.
- Document narrowly scoped Bandit suppressions for trusted server-generated pickle caches and the intentional Docker network binding.

## Testing

- Full GitHub Actions test matrix on Python 3.11–3.13 for Linux and macOS
- Website integration test
- Build and documentation checks
- Bandit medium/high-severity scan
- `pip-audit`
- Focused logging, Gaia-query, worker-artifact, and model-grid tests