### PR TITLE
Support configurable NIRCam readouts in the Groups & Integrations calculator

### DIFF
--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -290,6 +290,10 @@ def groups_integrations():
                   'filt_ta'.format(ins): getattr(form, '{}_filt_ta'.format(ins)).data,
                   'subarray_ta'.format(ins): getattr(form, '{}_subarray_ta'.format(ins)).data}
 
+        if ins == 'nircam':
+            params['num_amps'] = int(form.nircam_num_amps.data)
+            params['readout_pattern'] = form.nircam_readout_pattern.data
+
         # Get ngroups
         params['n_group'] = 'optimize' if form.n_group.data == 0 else int(form.n_group.data)
 
@@ -319,6 +323,10 @@ def groups_integrations():
                 results_dict['duration_time_ta_max'] = 0
             if results_dict['max_saturation_prediction'] > results_dict['sat_max']:
                 one_group_error = 'This many groups will oversaturate the detector! Proceed with caution!'
+            if results_dict.get('group_limit_applied'):
+                one_group_error = ('NIRCam is limited to 100 groups per integration in APT. '
+                                   'The result has been limited to 100; '
+                                   'consider a 1-amplifier readout or a different readout pattern.')
             # Do some formatting for a prettier end product
             results_dict['filt'] = results_dict['filt'].upper()
             results_dict['filt_ta'] = results_dict['filt_ta'].upper()

--- a/exoctk/exoctk_app/form_validation.py
+++ b/exoctk/exoctk_app/form_validation.py
@@ -80,6 +80,13 @@ class GroupsIntsForm(BaseForm):
     mod = SelectField('mod', choices=models)
     n_group = IntegerField('n_group', default=0)
     ins = SelectField('ins', default='miri', choices=[('niriss', 'NIRISS'), ('nircam', 'NIRCam'), ('nirspec', 'NIRSpec'), ('miri', 'MIRI')])
+    nircam_num_amps = SelectField('nircam_num_amps', default='4',
+                                  choices=[('4', '4 amplifiers'),
+                                           ('1', '1 amplifier')])
+    nircam_readout_pattern = SelectField(
+        'nircam_readout_pattern', default='rapid',
+        choices=[('rapid', 'RAPID'), ('bright2', 'BRIGHT2'),
+                 ('shallow4', 'SHALLOW4')])
 
     # Filter selects
     miri_filt = SelectField('miri_filt', choices=[('lrs', 'LRS')])

--- a/exoctk/exoctk_app/templates/groups_integrations.html
+++ b/exoctk/exoctk_app/templates/groups_integrations.html
@@ -20,7 +20,7 @@
         });  */
 
         $("#ins").change(function () {
-            $("#miri_filt, #nirspec_filt, #niriss_filt, #nircam_filt, #miri_filt_ta, #nirspec_filt_ta, #niriss_filt_ta, #nircam_filt_ta, #miri_sub, #nirspec_sub, #niriss_sub, #nircam_sub, #miri_sub_ta, #nircam_sub_ta, #niriss_sub_ta, #nirspec_sub_ta").hide();
+            $("#miri_filt, #nirspec_filt, #niriss_filt, #nircam_filt, #miri_filt_ta, #nirspec_filt_ta, #niriss_filt_ta, #nircam_filt_ta, #miri_sub, #nirspec_sub, #niriss_sub, #nircam_sub, #miri_sub_ta, #nircam_sub_ta, #niriss_sub_ta, #nirspec_sub_ta, #nircam-readout-section").hide();
             var selopt = $("#ins").val();
             switch (selopt) {
                 case "miri":
@@ -46,9 +46,11 @@
                     $("#nircam_filt_ta").show();
                     $("#nircam_sub").show();
                     $("#nircam_sub_ta").show();
+                    $("#nircam-readout-section").show();
                     break;
             }
         });
+        $("#ins").trigger("change");
     });
 </script>
 
@@ -70,7 +72,7 @@
         <br>
         1. At present, this tool is likely to overestimate saturation on direct comparison to the ETC. (This means we may predict less groups -- and put the user in less danger of oversaturating your observation)<br>
         2. Users should be aware of data rates.  There are maximum number of groups and integrations that each instrument (and APT) allows based on how much data JWST can store.  Therefore, results of this tool should always be checked against the documentation and APT.  More information can be found at the <a href="https://jwst-docs.stsci.edu/display/JDOX/JWST+Data+Rate+and+Data+Volume+Limits">"JWST Data Rate and Data Volume Limits" JDox page.</a><br>
-        3. For NIRCam, it is currently assumed that a 4-amplifier readout is needed. 1-amplifier readouts are currently not supported by this tool, but they are by, e.g., PandExo.<br>
+        3. NIRCam calculations are limited to the 100 groups per integration accepted by APT.<br>
     </p>
 
     <form class='form-horizontal' id='searchform' method='post'>
@@ -179,6 +181,20 @@
                     {% endfor %}
                 </select>
                 <span id="helpBlock" class="help-block">The JWST instrument</span>
+            </div>
+        </div>
+
+        <hr class="col-md-12">
+
+        <div class='form-group' id="nircam-readout-section" style="display:none;">
+            <label for='nircam_num_amps' class="col-sm-2 control-label">NIRCam Readout</label>
+            <div class="col-sm-3">
+                {{ form.nircam_num_amps(class='form-control') }}
+                <span class="help-block">Number of output amplifiers</span>
+            </div>
+            <div class="col-sm-3">
+                {{ form.nircam_readout_pattern(class='form-control') }}
+                <span class="help-block">Science readout pattern</span>
             </div>
         </div>
 

--- a/exoctk/exoctk_app/templates/groups_integrations_results.html
+++ b/exoctk/exoctk_app/templates/groups_integrations_results.html
@@ -97,6 +97,10 @@
                             <th>Subarray</th>
                             <th>Maximum Saturation Level</th>
                             <th> Frame Time </th>
+                            {% if results_dict['ins'] == 'NIRCam' %}
+                                <th> Amplifiers </th>
+                                <th> Readout Pattern </th>
+                            {% endif %}
                         </tr>
                         <tr>
                             <td>{{ results_dict['ins'] }}</td>
@@ -104,6 +108,10 @@
                             <td>{{ results_dict['subarray'] }}</td>
                             <td>{{ results_dict['sat_max']}}</td>
                             <td>{{ results_dict['frame_time'] }}</td>
+                            {% if results_dict['ins'] == 'NIRCam' %}
+                                <td>{{ results_dict['num_amps'] }}</td>
+                                <td>{{ results_dict['readout_pattern'] }}</td>
+                            {% endif %}
                         </tr>
                     </table>
                     </center>

--- a/exoctk/groups_integrations/groups_integrations.py
+++ b/exoctk/groups_integrations/groups_integrations.py
@@ -40,7 +40,8 @@ import numpy as np
 from scipy import interpolate
 
 
-def calc_duration_time(num_groups, num_integrations, num_reset_frames, frame_time, frames_per_group=1):
+def calc_duration_time(num_groups, num_integrations, num_reset_frames,
+                       frame_time, frames_per_group=1, num_skips=0):
     """Calculates duration time (or exposure duration as told by APT)
 
     Parameters
@@ -55,6 +56,8 @@ def calc_duration_time(num_groups, num_integrations, num_reset_frames, frame_tim
         Frame time (in seconds)
     frames_per_group : int, optional
         Frames per group -- always one except brown dwarves
+    num_skips : int, optional
+        Frames skipped between groups.
 
     Returns
     -------
@@ -62,7 +65,8 @@ def calc_duration_time(num_groups, num_integrations, num_reset_frames, frame_tim
         Duration time (in seconds).
     """
 
-    duration_time = frame_time * (num_groups * frames_per_group + num_reset_frames) * num_integrations
+    integration_frames = num_groups * (frames_per_group + num_skips) - num_skips
+    duration_time = frame_time * (integration_frames + num_reset_frames) * num_integrations
 
     return duration_time
 
@@ -170,7 +174,8 @@ def calc_integration_time(num_groups, frame_time, frames_per_group, num_skips):
     return integration_time
 
 
-def calc_num_integrations(transit_time, num_groups, num_reset_frames, frame_time, frames_per_group):
+def calc_num_integrations(transit_time, num_groups, num_reset_frames,
+                          frame_time, frames_per_group, num_skips=0):
     """Calculates number of integrations required.
 
     Parameters
@@ -185,6 +190,8 @@ def calc_num_integrations(transit_time, num_groups, num_reset_frames, frame_time
         The frame time (in seconds)
     frames_per_group : int
         Frames per group -- always 1 except maybe for brown dwarves
+    num_skips : int, optional
+        Frames skipped between groups.
 
     Returns
     -------
@@ -192,7 +199,10 @@ def calc_num_integrations(transit_time, num_groups, num_reset_frames, frame_time
         The required number of integraitions.
     """
 
-    num_integrations = math.ceil((float(transit_time) * 3600) / (frame_time * (num_groups * frames_per_group + num_reset_frames)))
+    integration_frames = num_groups * (frames_per_group + num_skips) - num_skips
+    num_integrations = math.ceil(
+        (float(transit_time) * 3600) /
+        (frame_time * (integration_frames + num_reset_frames)))
 
     return num_integrations
 
@@ -475,9 +485,26 @@ def perform_calculation(params, frames_per_group=1, num_skips=0):
     duration_time_ta_max = calc_duration_time(max_ta_groups, 1, 1, ta_frame_time)
 
     # Science obs
+    # NIRCam time-series observations support several readout patterns.  Keep
+    # RAPID as the default so existing API callers retain the old behaviour.
+    readout_patterns = {
+        'rapid': (1, 0),
+        'bright2': (2, 0),
+        'shallow4': (4, 1),
+    }
+    readout_pattern = str(params.get('readout_pattern', 'rapid')).lower()
+    if params['ins'] == 'nircam':
+        if readout_pattern not in readout_patterns:
+            raise ValueError('Unsupported NIRCam readout pattern: {}'.format(
+                readout_pattern))
+        frames_per_group, num_skips = readout_patterns[readout_pattern]
+    else:
+        readout_pattern = 'rapid'
+
     # Figure out the rows/cols/amps/pixel_size and saturation
-    instrument_params = set_params_from_instrument(params['ins'], params['subarray'])
-    frame_time = set_frame_time(params['infile'], params['ins'], params['subarray'])
+    requested_amps = params.get('num_amps') if params['ins'] == 'nircam' else None
+    instrument_params = set_params_from_instrument(
+        params['ins'], params['subarray'], requested_amps)
 
     # Run all the calculations
     num_rows, num_columns, num_amps, pixel_size, frame_time, num_reset_frames = instrument_params
@@ -487,10 +514,19 @@ def perform_calculation(params, frames_per_group=1, num_skips=0):
     num_groups, saturation_rate = interpolate_from_pandeia(
         params['mag'], params['ins'], params['filt'], params['subarray'], params['mod'], params['band'],
         frame_time, params['sat_max'], params['infile'])
+    if frames_per_group != 1 or num_skips:
+        max_exposure_frames = num_groups
+        num_groups = np.floor(
+            (max_exposure_frames + num_skips) /
+            (frames_per_group + num_skips))
+        num_groups = num_groups or 1
     if str(params['n_group']) == 'optimize':
         params['n_group'] = int(num_groups)
     else:
         params['n_group'] = int(float(params['n_group']))
+    if params['ins'] == 'nircam':
+        params['group_limit_applied'] = params['n_group'] > 100
+        params['n_group'] = min(params['n_group'], 100)
 
     # Aditional helpful params
     # Calculate times/ramps/etc
@@ -498,11 +534,15 @@ def perform_calculation(params, frames_per_group=1, num_skips=0):
     ramp_time = calc_ramp_time(integration_time, num_reset_frames, frame_time)
 
     # Calculate nubmer of integrations (THE MEAT)
-    num_integrations = calc_num_integrations(params['obs_time'], params['n_group'], num_reset_frames, frame_time, frames_per_group)
+    num_integrations = calc_num_integrations(
+        params['obs_time'], params['n_group'], num_reset_frames, frame_time,
+        frames_per_group, num_skips)
 
     # Other things that may come in handy who knows?
     exposure_time = calc_exposure_time(num_integrations, ramp_time)
-    duration_time = calc_duration_time(params['n_group'], num_integrations, num_reset_frames, frame_time, frames_per_group)
+    duration_time = calc_duration_time(
+        params['n_group'], num_integrations, num_reset_frames, frame_time,
+        frames_per_group, num_skips)
     observation_efficiency = calc_observation_efficiency(exposure_time, duration_time)
 
     # Update params with new information
@@ -513,7 +553,8 @@ def perform_calculation(params, frames_per_group=1, num_skips=0):
     params['frames_per_group'] = frames_per_group
     params['frame_time'] = round(frame_time, 3)
     params['integration_time'] = round(integration_time, 3)
-    params['max_saturation_prediction'] = round(saturation_rate * frame_time * params['n_group'], 3)
+    params['max_saturation_prediction'] = round(
+        saturation_rate * integration_time, 3)
     params['max_saturation_ta'] = round(saturation_rate_ta * ta_frame_time * max_ta_groups, 3)
     params['min_saturation_ta'] = round(saturation_rate_ta * ta_frame_time * min_ta_groups, 3)
     params['max_ta_groups'] = int(max_ta_groups)
@@ -524,6 +565,8 @@ def perform_calculation(params, frames_per_group=1, num_skips=0):
     params['num_reset_frames'] = num_reset_frames
     params['num_rows'] = num_rows
     params['num_skips'] = num_skips
+    if params['ins'] == 'nircam':
+        params['readout_pattern'] = readout_pattern.upper()
     params['observation_efficiency'] = round(observation_efficiency, 3)
     params['ramp_time'] = round(ramp_time, 3)
     params['ta_frame_time'] = ta_frame_time
@@ -531,7 +574,7 @@ def perform_calculation(params, frames_per_group=1, num_skips=0):
     return params
 
 
-def set_params_from_instrument(instrument, subarray):
+def set_params_from_instrument(instrument, subarray, num_amps=None):
     """Sets/collects the running parameters from the instrument.
 
     Parameters
@@ -576,13 +619,16 @@ def set_params_from_instrument(instrument, subarray):
 
         pixel_size = (18e-4)**2
         if subarray == 'full':
-            rows, cols, amps = 2048, 2048, 4
+            rows, cols = 2048, 2048
         elif subarray == 'subgrism256':
-            rows, cols, amps = 256, 256, 1
+            rows, cols = 256, 2048
         elif subarray == 'subgrism128':
-            rows, cols, amps = 128, 2048, 1
+            rows, cols = 128, 2048
         elif subarray == 'subgrism64':
-            rows, cols, amps = 64, 2048, 1
+            rows, cols = 64, 2048
+        amps = 4 if num_amps is None else int(num_amps)
+        if amps not in (1, 4):
+            raise ValueError('NIRCam num_amps must be 1 or 4')
         frame_time = calc_frame_time(cols, rows, amps, instrument)
 
     elif instrument == 'miri':

--- a/exoctk/tests/test_groups_integrations.py
+++ b/exoctk/tests/test_groups_integrations.py
@@ -57,6 +57,14 @@ NIRSPEC_PRISM_TEST_DATA = {
     'n_group': 'optimize',
     'infile': INFILE}
 
+NIRCAM_TEST_DATA = {
+    'ins': 'nircam', 'mag': Decimal('11.5'), 'obs_time': Decimal('3'),
+    'sat_max': Decimal('0.95'), 'sat_mode': 'well', 'time_unit': 'hour',
+    'band': 'K', 'mod': 'f5v', 'filt': 'f444w',
+    'subarray': 'subgrism256', 'filt_ta': 'f335m',
+    'subarray_ta': 'sub32tats', 'n_group': 'optimize', 'num_amps': 1,
+    'readout_pattern': 'shallow4', 'infile': INFILE}
+
 EXPECTED_RESULTS = {
     'ins': 'miri',
     'mag': Decimal('8.131'),
@@ -137,6 +145,14 @@ def test_calc_duration_time():
 
     duration_time = groups_integrations.calc_duration_time(36, 4674, 0, 0.159, 1)
     assert round(duration_time, 2) == 26753.98
+
+
+def test_calc_duration_time_with_skips():
+    """Tests that skipped frames are included in duration time."""
+
+    duration_time = groups_integrations.calc_duration_time(
+        3, 2, 1, 1, frames_per_group=4, num_skips=1)
+    assert duration_time == 30
 
 
 def test_calc_exposure_time():
@@ -230,6 +246,40 @@ def test_perform_calculation_nirspec_prism():
 
     params = groups_integrations.perform_calculation(NIRSPEC_PRISM_TEST_DATA.copy())
     assert params == NIRSPEC_PRISM_EXPECTED_RESULTS
+
+
+def test_perform_calculation_nircam_readout_options():
+    """Tests NIRCam amplifier and readout-pattern selections."""
+
+    params = groups_integrations.perform_calculation(NIRCAM_TEST_DATA.copy())
+    assert params['num_amps'] == 1
+    assert params['num_columns'] == 2048
+    assert params['frames_per_group'] == 4
+    assert params['num_skips'] == 1
+    assert params['readout_pattern'] == 'SHALLOW4'
+    assert params['frame_time'] == 5.294
+
+
+def test_nircam_group_limit():
+    """Tests the current APT limit of 100 groups per integration."""
+
+    test_data = NIRCAM_TEST_DATA.copy()
+    test_data['n_group'] = 101
+    params = groups_integrations.perform_calculation(test_data)
+    assert params['n_group'] == 100
+    assert params['group_limit_applied'] is True
+
+
+def test_set_params_from_instrument_nircam_amplifiers():
+    """Tests selectable NIRCam output amplifiers and grism dimensions."""
+
+    four_amp = groups_integrations.set_params_from_instrument(
+        'nircam', 'subgrism256', 4)
+    one_amp = groups_integrations.set_params_from_instrument(
+        'nircam', 'subgrism256', 1)
+    assert four_amp[:3] == (256, 2048, 4)
+    assert one_amp[:3] == (256, 2048, 1)
+    assert one_amp[4] > four_amp[4]
 
 
 def test_set_params_from_instrument():


### PR DESCRIPTION
## Summary

- Add selectable 1- and 4-amplifier NIRCam readouts.
- Add RAPID, BRIGHT2, and SHALLOW4 readout patterns.
- Account for frames and skipped frames when calculating integration and observation timing.
- Enforce the current NIRCam limit of 100 groups per integration.
- Correct the NIRCam grism dimensions used to calculate frame times.
- Display the selected amplifier count and readout pattern in the results.
- Add regression coverage for NIRCam readout options and group limits.

## Testing

- python -m pytest -q exoctk/tests/test_groups_integrations.py
- 20 tests passed

Closes #408