### PR TITLE
Guard unsupported contamination modes and expose NIRCam DHS calculations

### DIFF
--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -134,6 +134,20 @@ APERTURES = {'NIS_SOSSFULL': {'inst': 'NIRISS', 'full': 'NIS_SOSSFULL', 'scale':
              'NRCA5_GRISM256_F444W': {'inst': 'NIRCam', 'full': 'NRCA5_FULL', 'scale': 0.063, 'rad': 2.5, 'lam': [3.835, 5.084], 'trim': [0, 1, 1250, 1]},
              'MIRIM_SLITLESSPRISM': {'inst': 'MIRI', 'full': 'MIRIM_FULL', 'scale': 0.11, 'rad': 2.0, 'lam': [5, 12], 'trim': [6, 5, 0, 1]}}
 
+CONTAMINATION_APERTURES = frozenset({
+    'NIS_SOSSFULL',
+    'NIS_SUBSTRIP96',
+    'NIS_SUBSTRIP256',
+    'NRCA5_40STRIPE1_DHS_F322W2',
+    'NRCA5_40STRIPE1_DHS_F444W',
+})
+
+
+def contamination_supported(aperture):
+    """Return whether contamination calculations support an aperture."""
+
+    return aperture in CONTAMINATION_APERTURES
+
 DHS_STRIPES = {'NRCA5_40STRIPE1_DHS_F322W2': {'DHS5': {'x0': 2196, 'x1': 3324, 'y0': 2665, 'y1': 2671},
                                               'DHS4': {'x0': 2196, 'x1': 3324, 'y0': 2552, 'y1': 2558},
                                               'DHS3': {'x0': 2196, 'x1': 3324, 'y0': 2432, 'y1': 2438},

--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -134,8 +134,7 @@ APERTURES = {'NIS_SOSSFULL': {'inst': 'NIRISS', 'full': 'NIS_SOSSFULL', 'scale':
              'NRCA5_GRISM256_F444W': {'inst': 'NIRCam', 'full': 'NRCA5_FULL', 'scale': 0.063, 'rad': 2.5, 'lam': [3.835, 5.084], 'trim': [0, 1, 1250, 1]},
              'MIRIM_SLITLESSPRISM': {'inst': 'MIRI', 'full': 'MIRIM_FULL', 'scale': 0.11, 'rad': 2.0, 'lam': [5, 12], 'trim': [6, 5, 0, 1]}}
 
-CONTAMINATION_APERTURES = frozenset({
-    'NIS_SOSSFULL',
+WEB_CONTAMINATION_APERTURES = frozenset({
     'NIS_SUBSTRIP96',
     'NIS_SUBSTRIP256',
     'NRCA5_40STRIPE1_DHS_F322W2',
@@ -144,9 +143,9 @@ CONTAMINATION_APERTURES = frozenset({
 
 
 def contamination_supported(aperture):
-    """Return whether contamination calculations support an aperture."""
+    """Return whether the contamination web interface supports an aperture."""
 
-    return aperture in CONTAMINATION_APERTURES
+    return aperture in WEB_CONTAMINATION_APERTURES
 
 DHS_STRIPES = {'NRCA5_40STRIPE1_DHS_F322W2': {'DHS5': {'x0': 2196, 'x1': 3324, 'y0': 2665, 'y1': 2671},
                                               'DHS4': {'x0': 2196, 'x1': 3324, 'y0': 2552, 'y1': 2558},

--- a/exoctk/contam_visibility/modes.py
+++ b/exoctk/contam_visibility/modes.py
@@ -1,0 +1,15 @@
+"""Observing modes exposed by the contamination and visibility web form."""
+
+
+CONTAM_VISIBILITY_MODES = (
+    ('NIS_SUBSTRIP256', 'NIRISS - SOSS - SUBSTRIP256'),
+    ('NIS_SUBSTRIP96', 'NIRISS - SOSS - SUBSTRIP96'),
+    ('NRCA5_40STRIPE1_DHS_F322W2', 'NIRCam - DHS - F322W2'),
+    ('NRCA5_40STRIPE1_DHS_F444W', 'NIRCam - DHS - F444W'),
+    ('NRCA5_GRISM256_F322W2',
+     'NIRCam - Grism Time Series - F322W2 (Visibility Only)'),
+    ('NRCA5_GRISM256_F444W',
+     'NIRCam - Grism Time Series - F444W (Visibility Only)'),
+    ('MIRIM_SLITLESSPRISM', 'MIRI - LRS (Visibility Only)'),
+    ('NIRSpec', 'NIRSpec (Visibility Only)'),
+)

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -681,17 +681,28 @@ def contam_visibility():
             badPAs = [pa for pa in np.arange(0, 360) if pa not in results]
             print("Made PA list")
 
-            # Make old contam plot
-            starcube_targ = np.zeros((362, 2048, 96 if form.inst.data == 'NIS_SUBSTRIP96' else 256))
-            print("Starcube Step 1")
-            starcube_targ[0, :, :] = (targframe[0]).T[::-1, ::-1]
-            print("Starcube Step 2")
-            starcube_targ[1, :, :] = (targframe[1]).T[::-1, ::-1]
-            print("Starcube Step 3")
-            starcube_targ[2:, :, :] = starcube.swapaxes(1, 2)[:, ::-1, ::-1]
-            print("Made target starcube")
-            contam_plot = cf.contam(starcube_targ, form.inst.data, targetName=form.targname.data, badPAs=badPAs)
-            print("Made contamination Plot")
+            if 'DHS' in form.inst.data:
+                pctlines = fs.fraction_contaminated(
+                    form.inst.data, targframe, starcube)
+                contam_plot = cf.contam_slider_plot(pctlines, badPAs)
+                print("Made DHS contamination plot")
+            else:
+                # Make legacy SOSS contamination plot
+                starcube_targ = np.zeros(
+                    (362, 2048,
+                     96 if form.inst.data == 'NIS_SUBSTRIP96' else 256))
+                print("Starcube Step 1")
+                starcube_targ[0, :, :] = (targframe[0]).T[::-1, ::-1]
+                print("Starcube Step 2")
+                starcube_targ[1, :, :] = (targframe[1]).T[::-1, ::-1]
+                print("Starcube Step 3")
+                starcube_targ[2:, :, :] = starcube.swapaxes(
+                    1, 2)[:, ::-1, ::-1]
+                print("Made target starcube")
+                contam_plot = cf.contam(
+                    starcube_targ, form.inst.data,
+                    targetName=form.targname.data, badPAs=badPAs)
+                print("Made SOSS contamination plot")
 
             # Get scripts
             contam_js = INLINE.render_js()

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -451,7 +451,8 @@ def contam_visibility():
     """
     # Load default form
     form = fv.ContamVisForm()
-    form.calculate_contam_submit.disabled = False
+    form.calculate_contam_submit.disabled = not fs.contamination_supported(
+        form.inst.data)
 
     if request.method == 'GET':
 
@@ -497,15 +498,20 @@ def contam_visibility():
     if form.mode_submit.data:
 
         # Update the button
-        if form.inst.data == 'NIRSpec':
-            form.calculate_contam_submit.disabled = True
-        else:
-            form.calculate_contam_submit.disabled = False
+        form.calculate_contam_submit.disabled = not fs.contamination_supported(
+            form.inst.data)
 
         # Send it back to the main page
         return render_template('contam_visibility.html', form=form)
 
     if form.validate_on_submit() and (form.calculate_submit.data or form.calculate_contam_submit.data):
+
+        if (form.calculate_contam_submit.data and
+                not fs.contamination_supported(form.inst.data)):
+            form.calculate_contam_submit.disabled = True
+            form.inst.errors.append(
+                'Contamination calculations are available only for SOSS and DHS modes.')
+            return render_template('contam_visibility.html', form=form)
 
         if form.inst.data == "NIRSpec":
             instrument = form.inst.data

--- a/exoctk/exoctk_app/form_validation.py
+++ b/exoctk/exoctk_app/form_validation.py
@@ -9,6 +9,7 @@ from wtforms.validators import InputRequired, Length, NumberRange, AnyOf, Valida
 from wtforms.widgets import ListWidget, CheckboxInput
 
 from exoctk.modelgrid import ModelGrid
+from exoctk.contam_visibility.modes import CONTAM_VISIBILITY_MODES
 from exoctk.utils import get_env_variables, FILTERS_LIST, PROFILES
 from exoctk.throughputs import Throughput
 
@@ -42,7 +43,7 @@ class ContamVisForm(BaseForm):
     dec = DecimalField('dec', validators=[NumberRange(min=-90, max=90, message='Declinaton must be between -90 and 90 degrees')])
     v3pa = DecimalField('v3pa', default=-1, validators=[NumberRange(min=-1, max=360, message='PA must be between 0 and 360 degrees')])
     epoch = IntegerField('epoch', default=Time.now().value.year, validators=[NumberRange(min=2000, max=2050, message='Epoch must be between 2000 and 2050')])
-    inst = SelectField('inst', choices=[('NIS_SUBSTRIP256', 'NIRISS - SOSS - SUBSTRIP256'), ('NIS_SUBSTRIP96', 'NIRISS - SOSS - SUBSTRIP96'), ('NRCA5_40STRIPE1_DHS_F322W2', 'NIRCam - DHS - F322W2'), ('NRCA5_40STRIPE1_DHS_F444W', 'NIRCam - DHS - F444W'), ('NRCA5_GRISM256_F322W2', 'NIRCam - Grism Time Series - F322W2 (Visibility Only)'), ('NRCA5_GRISM256_F444W', 'NIRCam - Grism Time Series - F444W (Visibility Only)'), ('MIRIM_SLITLESSPRISM', 'MIRI - LRS (Visibility Only)'), ('NIRSpec', 'NIRSpec (Visibility Only)')])
+    inst = SelectField('inst', choices=CONTAM_VISIBILITY_MODES)
     delta_mag = DecimalField('delta_mag', default=None, validators=[Optional()])
     dist = DecimalField('dist', default=None, validators=[Optional()])
     pa = DecimalField('pa', default=None, validators=[Optional(), NumberRange(min=0, max=360, message='PA must be between 0 and 360 degrees')])

--- a/exoctk/exoctk_app/form_validation.py
+++ b/exoctk/exoctk_app/form_validation.py
@@ -42,7 +42,7 @@ class ContamVisForm(BaseForm):
     dec = DecimalField('dec', validators=[NumberRange(min=-90, max=90, message='Declinaton must be between -90 and 90 degrees')])
     v3pa = DecimalField('v3pa', default=-1, validators=[NumberRange(min=-1, max=360, message='PA must be between 0 and 360 degrees')])
     epoch = IntegerField('epoch', default=Time.now().value.year, validators=[NumberRange(min=2000, max=2050, message='Epoch must be between 2000 and 2050')])
-    inst = SelectField('inst', choices=[('NIS_SUBSTRIP256', 'NIRISS - SOSS - SUBSTRIP256'), ('NIS_SUBSTRIP96', 'NIRISS - SOSS - SUBSTRIP96'), ('NRCA5_GRISM256_F322W2', 'NIRCam - Grism Time Series - F322W2 (Visibility Only)'), ('NRCA5_GRISM256_F444W', 'NIRCam - Grism Time Series - F444W (Visibility Only)'), ('MIRIM_SLITLESSPRISM', 'MIRI - LRS (Visibility Only)'), ('NIRSpec', 'NIRSpec (Visibility Only)')])
+    inst = SelectField('inst', choices=[('NIS_SUBSTRIP256', 'NIRISS - SOSS - SUBSTRIP256'), ('NIS_SUBSTRIP96', 'NIRISS - SOSS - SUBSTRIP96'), ('NRCA5_40STRIPE1_DHS_F322W2', 'NIRCam - DHS - F322W2'), ('NRCA5_40STRIPE1_DHS_F444W', 'NIRCam - DHS - F444W'), ('NRCA5_GRISM256_F322W2', 'NIRCam - Grism Time Series - F322W2 (Visibility Only)'), ('NRCA5_GRISM256_F444W', 'NIRCam - Grism Time Series - F444W (Visibility Only)'), ('MIRIM_SLITLESSPRISM', 'MIRI - LRS (Visibility Only)'), ('NIRSpec', 'NIRSpec (Visibility Only)')])
     delta_mag = DecimalField('delta_mag', default=None, validators=[Optional()])
     dist = DecimalField('dist', default=None, validators=[Optional()])
     pa = DecimalField('pa', default=None, validators=[Optional(), NumberRange(min=0, max=360, message='PA must be between 0 and 360 degrees')])

--- a/exoctk/exoctk_app/templates/contam_visibility.html
+++ b/exoctk/exoctk_app/templates/contam_visibility.html
@@ -29,9 +29,26 @@
 
     $(document).ready(function(){
 
+        function contaminationSupported(mode) {
+            return mode === 'NIS_SOSSFULL' ||
+                   mode === 'NIS_SUBSTRIP96' ||
+                   mode === 'NIS_SUBSTRIP256' ||
+                   mode === 'NRCA5_40STRIPE1_DHS_F322W2' ||
+                   mode === 'NRCA5_40STRIPE1_DHS_F444W';
+        }
+
+        function updateContaminationButton() {
+            const supported = contaminationSupported($('#inst').val());
+            $('#calculate_contam_submit').prop('disabled', !supported);
+            $('#contamination-unavailable').prop('hidden', supported);
+        }
+
         $('#inst').on('change', function() {
+            updateContaminationButton();
             $('#modesubmit').click();
         });
+
+        updateContaminationButton();
 
         var task_value = document.getElementById("task_id").value;
         console.log("task value is:");
@@ -164,6 +181,9 @@
                             </div>
                         {% endfor %}
                     </select>
+					{% for error in form.inst.errors %}
+						<p style="color: red;">{{ error }}</p>
+					{% endfor %}
 				</div>
 		</div>
         {{ form.mode_submit(id='modesubmit', style="visibility: hidden;") }}
@@ -237,6 +257,9 @@
                 <p>
                     {{ form.calculate_contam_submit(disabled=form.calculate_contam_submit.disabled, class="btn btn-success") }}
                     <span id="helpBlock" class="help-block">Calculate the visibility and the contamination. Please be patient, this calculation takes a while.</span>
+                    <span id="contamination-unavailable" class="help-block" style="color: red;" hidden>
+                        Contamination calculations are available only for SOSS and DHS modes.
+                    </span>
                 </p>
             </div>
         </div>

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -89,3 +89,29 @@ def test_resolve_target():
 
     assert ra == 24.3544618
     assert dec == -45.6777937
+
+
+@pytest.mark.parametrize('aperture', [
+    'NIS_SOSSFULL',
+    'NIS_SUBSTRIP96',
+    'NIS_SUBSTRIP256',
+    'NRCA5_40STRIPE1_DHS_F322W2',
+    'NRCA5_40STRIPE1_DHS_F444W',
+])
+def test_contamination_supported(aperture):
+    """Contamination calculations support only SOSS and DHS apertures."""
+
+    assert field_simulator.contamination_supported(aperture)
+
+
+@pytest.mark.parametrize('aperture', [
+    'NRCA5_GRISM256_F322W2',
+    'NRCA5_GRISM256_F444W',
+    'MIRIM_SLITLESSPRISM',
+    'NIRSpec',
+    None,
+])
+def test_contamination_not_supported(aperture):
+    """Visibility-only modes must not run contamination calculations."""
+
+    assert not field_simulator.contamination_supported(aperture)

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -93,19 +93,19 @@ def test_resolve_target():
 
 
 @pytest.mark.parametrize('aperture', [
-    'NIS_SOSSFULL',
     'NIS_SUBSTRIP96',
     'NIS_SUBSTRIP256',
     'NRCA5_40STRIPE1_DHS_F322W2',
     'NRCA5_40STRIPE1_DHS_F444W',
 ])
 def test_contamination_supported(aperture):
-    """Contamination calculations support only SOSS and DHS apertures."""
+    """The web interface enables contamination only for its supported modes."""
 
     assert field_simulator.contamination_supported(aperture)
 
 
 @pytest.mark.parametrize('aperture', [
+    'NIS_SOSSFULL',
     'NRCA5_GRISM256_F322W2',
     'NRCA5_GRISM256_F444W',
     'MIRIM_SLITLESSPRISM',

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -32,7 +32,7 @@ from pandas import DataFrame
 from exoctk.contam_visibility import field_simulator
 from exoctk.contam_visibility import resolve
 from exoctk.contam_visibility import new_vis_plot
-from exoctk.exoctk_app.form_validation import ContamVisForm
+from exoctk.contam_visibility.modes import CONTAM_VISIBILITY_MODES
 
 # Determine if tests are being run on Github Actions
 ON_GITHUB_ACTIONS = '/home/runner' in os.path.expanduser('~') or '/Users/runner' in os.path.expanduser('~')
@@ -121,6 +121,6 @@ def test_contamination_not_supported(aperture):
 def test_dhs_modes_available_in_web_form():
     """The web form exposes both supported NIRCam DHS filters."""
 
-    choices = dict(ContamVisForm.inst.kwargs['choices'])
+    choices = dict(CONTAM_VISIBILITY_MODES)
     assert choices['NRCA5_40STRIPE1_DHS_F322W2'] == 'NIRCam - DHS - F322W2'
     assert choices['NRCA5_40STRIPE1_DHS_F444W'] == 'NIRCam - DHS - F444W'

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -32,6 +32,7 @@ from pandas import DataFrame
 from exoctk.contam_visibility import field_simulator
 from exoctk.contam_visibility import resolve
 from exoctk.contam_visibility import new_vis_plot
+from exoctk.exoctk_app.form_validation import ContamVisForm
 
 # Determine if tests are being run on Github Actions
 ON_GITHUB_ACTIONS = '/home/runner' in os.path.expanduser('~') or '/Users/runner' in os.path.expanduser('~')
@@ -115,3 +116,11 @@ def test_contamination_not_supported(aperture):
     """Visibility-only modes must not run contamination calculations."""
 
     assert not field_simulator.contamination_supported(aperture)
+
+
+def test_dhs_modes_available_in_web_form():
+    """The web form exposes both supported NIRCam DHS filters."""
+
+    choices = dict(ContamVisForm.inst.kwargs['choices'])
+    assert choices['NRCA5_40STRIPE1_DHS_F322W2'] == 'NIRCam - DHS - F322W2'
+    assert choices['NRCA5_40STRIPE1_DHS_F444W'] == 'NIRCam - DHS - F444W'


### PR DESCRIPTION
## Summary

- Disable Calculate Visibility and Contamination for modes that do not support contamination calculations.
- Show an immediate message explaining that contamination calculations are limited to SOSS and DHS.
- Add server-side validation to prevent unsupported requests from dispatching background tasks.
- Add NIRCam DHS F322W2 and F444W options to the web form.
- Route all-position-angle DHS results through the generalized fractional-contamination slider.
- Preserve the existing SOSS results path.
- Add regression coverage for supported apertures, visibility-only modes, and DHS form options.

## Testing

- pytest exoctk/tests
- 73 tests passed.
- 2 existing SOSS simulation tests failed because my local contamination data bundle contains NIS_order0.npy, while the current code expects temperature-specific NIS_order0_*.npy files.
- The focused tests for these changes passed.

## Notes

The two data-dependent failures are unrelated to the UI and request-validation changes. They indicate that my local contamination data bundle needs to be updated or that get_order0() needs a fallback for the legacy NIS_order0.npy file.