### PR TITLE
Update ExoCTK data downloads and harden visibility tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,43 +75,16 @@ jobs:
           echo "export PYTHON_VERSION=3.11" >> ./docker/.env
           echo "export EXO_SOURCE=copy" >> ./docker/.env
 
+      - name: Build ExoCTK
+        working-directory: ./docker
+        run: docker compose build exoctk
+
       - name: Download ExoCTK Data
-        working-directory: /tmp/exoctk/data
+        working-directory: ./docker
         run: |
-          echo "Downloading ExoCTK Data"
-          # all.zip contains only an empty all/ directory.
-          # curl -L https://stsci.box.com/shared/static/grztwf220jnvamzv8ugb7phj9tlwnoi1 -o output.zip
-          # unzip -o output.zip
-          # rm output.zip
-
-          curl -L https://stsci.box.com/shared/static/zhrx2r6kgeovcnj78d4wicb7m2009qca -o output.zip
-          unzip -o output.zip
-          rm output.zip
-
-          # The website creates its logging database when one is not present.
-          # curl -L https://stsci.box.com/shared/static/4q75kt2xelk3zox26vii1i3clnm7nzt7 -o output.zip
-          # unzip -o output.zip
-          # rm output.zip
-
-          curl -L https://stsci.box.com/shared/static/702r4nkccc484noiggq5xt13agbkkevp -o output.zip
-          unzip -o output.zip
-          rm output.zip
-
-          curl -L https://stsci.box.com/shared/static/p64c53rky00ojz1gvabe9hqirpat9azz -o output.zip
-          unzip -o output.zip
-          rm output.zip
-
-          # Groups/Integrations uses the JSON data packaged with ExoCTK.
-          # curl -L https://stsci.box.com/shared/static/1ag5x8ii1ko8h6lnoxwxljgdfw2mp894 -o output.zip
-          # unzip -o output.zip
-          # rm output.zip
-
-          curl -L https://stsci.box.com/shared/static/vcn1ff9nzg2qx3pnkmsz17dujjdzlsh1 -o output.zip
-          unzip -o output.zip
-          rm output.zip
-
-          echo "ExoCTK data is installed"
-
+          docker compose run --rm --no-deps \
+            --entrypoint python exoctk \
+            -c "from exoctk.utils import download_exoctk_data; download_exoctk_data('all')"
 
       - name: Start Redis
         run: docker compose up redis -d

--- a/docker/exoctk/test_exoctk_page.py
+++ b/docker/exoctk/test_exoctk_page.py
@@ -72,6 +72,7 @@ from tabulate import tabulate
 
 
 PROGRESS_INTERVAL = 30
+PAGE_LOAD_TIMEOUT = 150
 
 
 def log(message=""):
@@ -231,7 +232,7 @@ def do_submit(driver, params, calculation_timeout=2700):
             f'result element {locator!r}')
         next_report = PROGRESS_INTERVAL
         while True:
-            if '500 Internal Server Error' in driver.title:
+            if 'internal server error' in driver.title.lower():
                 elapsed = time.monotonic() - started
                 log(f'[{test_name}] HTTP 500 detected after {elapsed:.1f} '
                     f'seconds; URL={driver.current_url!r}')
@@ -274,6 +275,7 @@ def do_form(options, service, params):
     log(run_str)
     log("-" * len(run_str))
     with webdriver.Firefox(options=options, service=service) as driver:
+        driver.set_page_load_timeout(PAGE_LOAD_TIMEOUT)
         test_url = params['url'] + params['extension']
         log(f'[{test_name}] Loading {test_url}')
         driver.get(test_url)

--- a/exoctk/contam_visibility/new_vis_plot.py
+++ b/exoctk/contam_visibility/new_vis_plot.py
@@ -1,10 +1,89 @@
+import datetime
+import os
+import re
+import warnings
+
 from astropy.time import Time
 
 from bokeh.models import Band, ColumnDataSource, HoverTool
 from bokeh.plotting import figure, show
 
-from jwst_gtvt.jwst_tvt import Ephemeris
+import numpy as np
+import requests
+
+from jwst_gtvt.constants import URL
+from jwst_gtvt.jwst_tvt import Ephemeris, LAUNCH_DATE
 from jwst_gtvt.plotting import get_visibility_windows
+
+
+HORIZONS_TIMEOUT = (5, 30)
+HORIZONS_KNOWN_MAX_DATE = '2030-03-16'
+LOCAL_EPHEMERIS_PATTERN = re.compile(
+    r'ephemeris_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})\.txt$')
+
+
+class EphemerisUnavailableError(RuntimeError):
+    """Raised when neither Horizons nor a complete local ephemeris is available."""
+
+
+class BoundedEphemeris(Ephemeris):
+    """Retrieve Horizons data with bounded requests and a safe local fallback."""
+
+    request_timeout = HORIZONS_TIMEOUT
+
+    def ephemeris_maximum_date(self):
+        """Retrieve the last available date without waiting indefinitely."""
+
+        request_url = URL.format(LAUNCH_DATE, '9999-01-01')
+        try:
+            response = requests.get(request_url, timeout=self.request_timeout)
+            response.raise_for_status()
+            match = re.search(
+                r'after A\.D\. (\d{4}-[a-zA-Z]+-\d{1,2})',
+                response.text)
+            if match is None:
+                raise ValueError('Unable to parse the Horizons maximum date')
+            return datetime.datetime.strptime(
+                match.group(1), '%Y-%b-%d').strftime('%Y-%m-%d')
+        except (requests.RequestException, ValueError):
+            return HORIZONS_KNOWN_MAX_DATE
+
+    def get_ephemeris_data(self, start_date=None, end_date=None):
+        """Retrieve ephemeris data or use a local file with full coverage."""
+
+        self.url = URL.format(start_date, end_date)
+        try:
+            self.eph_request = requests.get(
+                self.url, timeout=self.request_timeout)
+            self.eph_request.raise_for_status()
+            return np.asarray(self.eph_request.text.splitlines())
+        except requests.RequestException as exc:
+            return self._read_local_ephemeris(start_date, end_date, exc)
+
+    def _read_local_ephemeris(self, start_date, end_date, request_error):
+        """Read the packaged ephemeris only when it covers the request."""
+
+        filename = os.path.basename(self.ephemeris_filename)
+        match = LOCAL_EPHEMERIS_PATTERN.fullmatch(filename)
+        if match is None:
+            raise EphemerisUnavailableError(
+                'Horizons is unavailable and the packaged ephemeris '
+                f'filename does not declare its coverage: {filename}'
+            ) from request_error
+
+        local_start, local_end = match.groups()
+        if start_date < local_start or end_date > local_end:
+            raise EphemerisUnavailableError(
+                'Horizons is unavailable and the packaged ephemeris covers '
+                f'{local_start} through {local_end}, not the requested '
+                f'{start_date} through {end_date}.'
+            ) from request_error
+
+        warnings.warn(
+            f'Horizons is unavailable; using packaged ephemeris {filename}.',
+            RuntimeWarning)
+        with open(self.ephemeris_filename) as handle:
+            return np.asarray(handle.read().splitlines())
 
 
 def get_exoplanet_positions(ra, dec, in_FOR=None):
@@ -27,7 +106,8 @@ def get_exoplanet_positions(ra, dec, in_FOR=None):
         dec = dec[:-1]
 
     # Set ephemeris to go from Cycle 3 to Cycle 6:
-    eph = Ephemeris(start_date=Time('2024-07-30'), end_date=Time('2028-07-30'))
+    eph = BoundedEphemeris(
+        start_date=Time('2024-07-30'), end_date=Time('2028-07-30'))
     exoplanet_data = eph.get_fixed_target_positions(ra, dec)
 
     if in_FOR is None:
@@ -36,7 +116,8 @@ def get_exoplanet_positions(ra, dec, in_FOR=None):
         return exoplanet_data.loc[exoplanet_data['in_FOR']==in_FOR]
 
 
-def build_visibility_plot(target_name, instrument, ra, dec):
+def build_visibility_plot(target_name, instrument, ra, dec,
+                          exoplanet_df=None):
     """Build bokeh figure for visibility windows
     """
 
@@ -49,8 +130,10 @@ def build_visibility_plot(target_name, instrument, ra, dec):
     min_pa_column_name = instrument + '_min_pa_angle'
     max_pa_column_name = instrument + '_max_pa_angle'
 
-    # obtain exoplanet data and filter visibility windows
-    exoplanet_df = get_exoplanet_positions(ra, dec, in_FOR=True)
+    # Obtain exoplanet data when it was not already calculated for the table.
+    if exoplanet_df is None:
+        exoplanet_df = get_exoplanet_positions(ra, dec)
+    exoplanet_df = exoplanet_df.loc[exoplanet_df['in_FOR']].copy()
     window_indices = get_visibility_windows(exoplanet_df.index.tolist())
 
     exoplanet_df['times'] = Time(exoplanet_df['MJD'], format='mjd').datetime

--- a/exoctk/contam_visibility/new_vis_plot.py
+++ b/exoctk/contam_visibility/new_vis_plot.py
@@ -17,7 +17,7 @@ from jwst_gtvt.plotting import get_visibility_windows
 
 
 HORIZONS_TIMEOUT = (5, 30)
-HORIZONS_KNOWN_MAX_DATE = '2030-03-16'
+VISIBILITY_RANGE_YEARS = 2
 LOCAL_EPHEMERIS_PATTERN = re.compile(
     r'ephemeris_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})\.txt$')
 
@@ -26,10 +26,43 @@ class EphemerisUnavailableError(RuntimeError):
     """Raised when neither Horizons nor a complete local ephemeris is available."""
 
 
+class InvalidHorizonsResponseError(RuntimeError):
+    """Raised when Horizons responds without ephemeris vector data."""
+
+
+def visibility_date_range(reference_date=None):
+    """Return a rolling visibility range starting on the current UTC date."""
+
+    if reference_date is None:
+        reference_date = datetime.datetime.now(datetime.timezone.utc).date()
+
+    try:
+        end_date = reference_date.replace(
+            year=reference_date.year + VISIBILITY_RANGE_YEARS)
+    except ValueError:
+        # Map February 29 to February 28 when the end year is not a leap year.
+        end_date = reference_date.replace(
+            year=reference_date.year + VISIBILITY_RANGE_YEARS,
+            month=2, day=28)
+
+    return Time(reference_date.isoformat()), Time(end_date.isoformat())
+
+
 class BoundedEphemeris(Ephemeris):
     """Retrieve Horizons data with bounded requests and a safe local fallback."""
 
     request_timeout = HORIZONS_TIMEOUT
+
+    def __init__(self, start_date=None, end_date=None):
+        if start_date is None or end_date is None:
+            default_start, default_end = visibility_date_range()
+            start_date = default_start if start_date is None else start_date
+            end_date = default_end if end_date is None else end_date
+
+        start_date = Time(start_date)
+        end_date = Time(end_date)
+        self._requested_end_date = end_date.strftime('%Y-%m-%d')
+        super().__init__(start_date=start_date, end_date=end_date)
 
     def ephemeris_maximum_date(self):
         """Retrieve the last available date without waiting indefinitely."""
@@ -46,7 +79,9 @@ class BoundedEphemeris(Ephemeris):
             return datetime.datetime.strptime(
                 match.group(1), '%Y-%b-%d').strftime('%Y-%m-%d')
         except (requests.RequestException, ValueError):
-            return HORIZONS_KNOWN_MAX_DATE
+            # Let the bounded data request determine whether this date is
+            # available instead of relying on a maximum date that goes stale.
+            return self._requested_end_date
 
     def get_ephemeris_data(self, start_date=None, end_date=None):
         """Retrieve ephemeris data or use a local file with full coverage."""
@@ -56,8 +91,13 @@ class BoundedEphemeris(Ephemeris):
             self.eph_request = requests.get(
                 self.url, timeout=self.request_timeout)
             self.eph_request.raise_for_status()
-            return np.asarray(self.eph_request.text.splitlines())
-        except requests.RequestException as exc:
+            ephemeris = np.asarray(self.eph_request.text.splitlines())
+            if '$$SOE' not in ephemeris or '$$EOE' not in ephemeris:
+                raise InvalidHorizonsResponseError(
+                    'Horizons response did not contain ephemeris vector data')
+            return ephemeris
+        except (requests.RequestException,
+                InvalidHorizonsResponseError) as exc:
             return self._read_local_ephemeris(start_date, end_date, exc)
 
     def _read_local_ephemeris(self, start_date, end_date, request_error):
@@ -105,9 +145,7 @@ def get_exoplanet_positions(ra, dec, in_FOR=None):
     while dec[-1] not in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.']:
         dec = dec[:-1]
 
-    # Set ephemeris to go from Cycle 3 to Cycle 6:
-    eph = BoundedEphemeris(
-        start_date=Time('2024-07-30'), end_date=Time('2028-07-30'))
+    eph = BoundedEphemeris()
     exoplanet_data = eph.get_fixed_target_positions(ra, dec)
 
     if in_FOR is None:

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -574,8 +574,10 @@ def contam_visibility():
 
         # Make plot
         title = form.targname.data or ', '.join([str(form.ra.data), str(form.dec.data)])
-        vis_plot = build_visibility_plot(str(title), instrument, str(form.ra.data), str(form.dec.data))
         table = get_exoplanet_positions(str(form.ra.data), str(form.dec.data))
+        vis_plot = build_visibility_plot(
+            str(title), instrument, str(form.ra.data), str(form.dec.data),
+            exoplanet_df=table)
 
         # Make output table
         vis_table_file = os.path.join(os.environ["SHARED_DATA_DIR"], f"{uuid.uuid4()}.csv")

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -32,6 +32,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import pysiaf
+import requests
 
 from pandas import DataFrame
 from astropy.io import fits
@@ -107,9 +108,85 @@ def test_new_vis_plot():
 
     assert isinstance(table, DataFrame)
 
-    plt = new_vis_plot.build_visibility_plot('WASP-18b', 'NIRISS', ra, dec)
+    plt = new_vis_plot.build_visibility_plot(
+        'WASP-18b', 'NIRISS', ra, dec, exoplanet_df=table)
 
     assert str(type(plt)) == "<class 'bokeh.plotting._figure.figure'>"
+
+
+def test_bounded_ephemeris_requests_have_timeouts(monkeypatch, tmp_path):
+    """Horizons requests are bounded and incomplete local data is rejected."""
+
+    requests_seen = []
+
+    def timeout(url, timeout):
+        requests_seen.append((url, timeout))
+        raise requests.Timeout('Horizons did not respond')
+
+    monkeypatch.setattr(new_vis_plot.requests, 'get', timeout)
+
+    ephemeris = new_vis_plot.BoundedEphemeris.__new__(
+        new_vis_plot.BoundedEphemeris)
+    local_file = tmp_path / 'ephemeris_2021-12-26_2025-06-12.txt'
+    local_file.write_text('local ephemeris')
+    ephemeris.ephemeris_filename = str(local_file)
+
+    assert (ephemeris.ephemeris_maximum_date() ==
+            new_vis_plot.HORIZONS_KNOWN_MAX_DATE)
+    with pytest.raises(
+            new_vis_plot.EphemerisUnavailableError,
+            match='not the requested 2024-07-30 through 2028-07-30'):
+        ephemeris.get_ephemeris_data('2024-07-30', '2028-07-30')
+
+    assert len(requests_seen) == 2
+    assert all(timeout == new_vis_plot.HORIZONS_TIMEOUT
+               for _, timeout in requests_seen)
+
+
+def test_bounded_ephemeris_uses_complete_local_data(monkeypatch, tmp_path):
+    """A packaged ephemeris is used when it covers the full request."""
+
+    monkeypatch.setattr(
+        new_vis_plot.requests, 'get',
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            requests.Timeout('Horizons did not respond')))
+
+    ephemeris = new_vis_plot.BoundedEphemeris.__new__(
+        new_vis_plot.BoundedEphemeris)
+    local_file = tmp_path / 'ephemeris_2024-01-01_2029-01-01.txt'
+    local_file.write_text('first line\nsecond line\n')
+    ephemeris.ephemeris_filename = str(local_file)
+
+    with pytest.warns(RuntimeWarning, match='using packaged ephemeris'):
+        result = ephemeris.get_ephemeris_data(
+            '2024-07-30', '2028-07-30')
+
+    assert result.tolist() == ['first line', 'second line']
+
+
+def test_build_visibility_plot_reuses_positions(monkeypatch):
+    """Precomputed positions avoid another Horizons query."""
+
+    positions = DataFrame({
+        'in_FOR': [True, True],
+        'MJD': [60000., 60001.],
+        'NIRISS_nominal_angle': [10., 11.],
+        'NIRISS_min_pa_angle': [5., 6.],
+        'NIRISS_max_pa_angle': [15., 16.],
+    })
+    monkeypatch.setattr(
+        new_vis_plot, 'get_exoplanet_positions',
+        lambda *args, **kwargs: pytest.fail(
+            'positions should not be recalculated'))
+    monkeypatch.setattr(
+        new_vis_plot, 'get_visibility_windows',
+        lambda indices: [(indices[0], indices[-1])])
+
+    plot = new_vis_plot.build_visibility_plot(
+        'Target', 'NIRISS', '1', '2', exoplanet_df=positions)
+
+    assert str(type(plot)) == "<class 'bokeh.plotting._figure.figure'>"
+    assert 'times' not in positions
 
 
 @pytest.mark.skipif(ON_GITHUB_ACTIONS, reason='Need access to trace data FITS files.  Please try running locally')

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -20,6 +20,7 @@ Use
         pytest -s test_contam_visibility.py
 """
 
+import datetime
 import json
 import os
 import pickle
@@ -127,12 +128,12 @@ def test_bounded_ephemeris_requests_have_timeouts(monkeypatch, tmp_path):
 
     ephemeris = new_vis_plot.BoundedEphemeris.__new__(
         new_vis_plot.BoundedEphemeris)
+    ephemeris._requested_end_date = '2028-07-30'
     local_file = tmp_path / 'ephemeris_2021-12-26_2025-06-12.txt'
     local_file.write_text('local ephemeris')
     ephemeris.ephemeris_filename = str(local_file)
 
-    assert (ephemeris.ephemeris_maximum_date() ==
-            new_vis_plot.HORIZONS_KNOWN_MAX_DATE)
+    assert ephemeris.ephemeris_maximum_date() == '2028-07-30'
     with pytest.raises(
             new_vis_plot.EphemerisUnavailableError,
             match='not the requested 2024-07-30 through 2028-07-30'):
@@ -141,6 +142,39 @@ def test_bounded_ephemeris_requests_have_timeouts(monkeypatch, tmp_path):
     assert len(requests_seen) == 2
     assert all(timeout == new_vis_plot.HORIZONS_TIMEOUT
                for _, timeout in requests_seen)
+
+
+def test_visibility_date_range_rolls_forward_two_years():
+    """Visibility calculations use a rolling two-year planning window."""
+
+    start_date, end_date = new_vis_plot.visibility_date_range(
+        datetime.date(2026, 7, 30))
+
+    assert start_date.strftime('%Y-%m-%d') == '2026-07-30'
+    assert end_date.strftime('%Y-%m-%d') == '2028-07-30'
+
+
+def test_bounded_ephemeris_rejects_invalid_horizons_response(
+        monkeypatch, tmp_path):
+    """An HTTP success without vector data is not treated as an ephemeris."""
+
+    response = SimpleNamespace(
+        text='Horizons returned an explanatory error',
+        raise_for_status=lambda: None)
+    monkeypatch.setattr(
+        new_vis_plot.requests, 'get',
+        lambda *args, **kwargs: response)
+
+    ephemeris = new_vis_plot.BoundedEphemeris.__new__(
+        new_vis_plot.BoundedEphemeris)
+    local_file = tmp_path / 'ephemeris_2021-12-26_2025-06-12.txt'
+    local_file.write_text('local ephemeris')
+    ephemeris.ephemeris_filename = str(local_file)
+
+    with pytest.raises(
+            new_vis_plot.EphemerisUnavailableError,
+            match='not the requested 2026-07-30 through 2028-07-30'):
+        ephemeris.get_ephemeris_data('2026-07-30', '2028-07-30')
 
 
 def test_bounded_ephemeris_uses_complete_local_data(monkeypatch, tmp_path):

--- a/exoctk/tests/test_utils.py
+++ b/exoctk/tests/test_utils.py
@@ -17,11 +17,14 @@ Use
         pytest -s test_utils.py
 """
 
+import os
+
 from astropy.table import Table
 import numpy as np
 import pytest
+import requests
 
-from exoctk.utils import color_gen, filter_table, get_canonical_name, get_target_data, medfilt
+from exoctk.utils import DATA_URLS, color_gen, download_exoctk_data, filter_table, get_canonical_name, get_target_data, medfilt
 
 ARGS = ['planet_name', 'planet_data']
 
@@ -84,3 +87,71 @@ def test_color_gen(colormap):
 @pytest.mark.parametrize(['data', 'filter_window'], MEDFILT_DATA)
 def test_medfilt(data, filter_window):
     medfilt(data, filter_window)
+
+
+def test_download_exoctk_data_uses_selected_package_and_log(tmp_path, monkeypatch):
+    """Only the requested package and log archive should be downloaded."""
+
+    requests_seen = []
+    archives_seen = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            yield b'archive data'
+
+    def get(url, **kwargs):
+        requests_seen.append((url, kwargs))
+        return Response()
+
+    def unpack_archive(path, destination):
+        archives_seen.append((path, destination))
+
+    monkeypatch.setattr(requests, 'get', get)
+    monkeypatch.setattr('exoctk.utils.shutil.unpack_archive', unpack_archive)
+
+    contam_urls = list(DATA_URLS['exoctk_contam'])
+    log_urls = list(DATA_URLS['exoctk_log'])
+    download_exoctk_data('exoctk_contam', str(tmp_path))
+
+    assert [url for url, _ in requests_seen] == contam_urls + log_urls
+    assert all(kwargs == {'stream': True, 'timeout': 60} for _, kwargs in requests_seen)
+    assert len(archives_seen) == 2
+    assert all(destination == str(tmp_path) for _, destination in archives_seen)
+    assert [os.path.basename(path) for path, _ in archives_seen] == [
+        'exoctk_contam.tar.gz',
+        'exoctk_log.tar.gz',
+    ]
+    assert DATA_URLS['exoctk_contam'] == contam_urls
+
+
+def test_download_exoctk_data_reports_http_failure(tmp_path, monkeypatch):
+    """An HTTP error should not be passed to the archive extractor."""
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def raise_for_status(self):
+            raise requests.HTTPError('404 Not Found')
+
+        def iter_content(self, chunk_size):
+            yield b'not reached'
+
+    monkeypatch.setattr('exoctk.utils.requests.get', lambda *args, **kwargs: Response())
+
+    with pytest.raises(RuntimeError, match='Unable to download ExoCTK data'):
+        download_exoctk_data('exoctk_contam', str(tmp_path))
+
+    assert list(tmp_path.iterdir()) == []

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -23,8 +23,6 @@ import numpy as np
 from svo_filters import svo
 from bokeh.plotting import figure, show
 
-from ._version import __version__
-
 try:
     from .throughputs import JWST_THROUGHPUTS
 
@@ -40,23 +38,26 @@ except TypeError:
 # Supported profiles
 PROFILES = ['linear', 'quadratic', 'square-root', 'logarithmic', 'exponential', '3-parameter', '4-parameter']
 
-PATCHVER = 'v' + '.'.join(__version__.split('.')[:2]) # So we don't have to update EXOCTK_DATA for nano releases
+# The ExoCTK data packages are distributed as versioned tar archives.  These
+# links are also used by the website test workflow.
+DATA_URL_BASE = 'https://data.science.stsci.edu/redirect/JWST/ExoCTK/exoctk_data_v2026p7/compressed/'
 DATA_URLS = {
-    'exoctk_contam': [f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/exoctk_contam{PATCHVER}.tar.gz'],
-    'groups_integrations': [f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/groups_integrations{PATCHVER}.tar.gz'],
-    'fortney': [f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/fortney{PATCHVER}.tar.gz'],
-    'generic': [f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/generic{PATCHVER}.tar.gz'],
-    'exoctk_log': [f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/exoctk_log{PATCHVER}.tar.gz'],
-    'modelgrid': [f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/modelgrid_ATLAS9{PATCHVER}.tar.gz',
-                  f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/modelgrid_ACES_1{PATCHVER}.tar.gz',
-                  f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/modelgrid_ACES_2{PATCHVER}.tar.gz'],
-    'all': [f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/modelgrid_ATLAS9{PATCHVER}.tar.gz',
-            f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/modelgrid_ACES_1{PATCHVER}.tar.gz',
-            f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/modelgrid_ACES_2{PATCHVER}.tar.gz',
-            f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/generic{PATCHVER}.tar.gz',
-            f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/fortney{PATCHVER}.tar.gz',
-            f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/groups_integrations{PATCHVER}.tar.gz',
-            f'https://data.science.stsci.edu/redirect/JWST/ExoCTK/compressed/exoctk_contam{PATCHVER}.tar.gz']}
+    'exoctk_contam': [DATA_URL_BASE + 'exoctk_contam.tar.gz'],
+    'groups_integrations': [DATA_URL_BASE + 'groups_integrations.tar.gz'],
+    'fortney': [DATA_URL_BASE + 'fortney.tar.gz'],
+    'generic': [DATA_URL_BASE + 'generic.tar.gz'],
+    'exoctk_log': [DATA_URL_BASE + 'exoctk_log.tar.gz'],
+    'modelgrid': [DATA_URL_BASE + 'modelgrid_ATLAS9.tar.gz',
+                  DATA_URL_BASE + 'modelgrid_ACES_1.tar.gz',
+                  DATA_URL_BASE + 'modelgrid_ACES_2.tar.gz'],
+    'all': [DATA_URL_BASE + 'modelgrid_ATLAS9.tar.gz',
+            DATA_URL_BASE + 'modelgrid_ACES_1.tar.gz',
+            DATA_URL_BASE + 'modelgrid_ACES_2.tar.gz',
+            DATA_URL_BASE + 'generic.tar.gz',
+            DATA_URL_BASE + 'fortney.tar.gz',
+            DATA_URL_BASE + 'groups_integrations.tar.gz',
+            DATA_URL_BASE + 'exoctk_contam.tar.gz',
+            DATA_URL_BASE + 'exoctk_log.tar.gz']}
 
 # If the variable is blank or doesn't exist
 HOME_DIR = os.path.expanduser('~')
@@ -385,14 +386,15 @@ COLORS = color_gen('Category10')
 
 
 def download_exoctk_data(tool='all', exoctk_data_dir=EXOCTK_DATA):
-    """Retrieves the ``exoctk_data`` materials from Box, downloads them
+    """Retrieves the ``exoctk_data`` materials, downloads them
     to the user's local machine, uncompresses the files, and arranges
     them into an ``exoctk_data`` directory.
 
     Parameters
     ----------
     tool: str
-        The ExoCTK tool data to download
+        The ExoCTK tool data to download.  ``all`` downloads every package;
+        individual package names can be used to limit the download.
     exoctk_data_dir : string
         The path to where the ExoCTK data package will be downloaded.
         The default setting is the user's $HOME directory.
@@ -412,55 +414,73 @@ def download_exoctk_data(tool='all', exoctk_data_dir=EXOCTK_DATA):
     except PermissionError:
         print('Data download failed.  Unable to create {}.  Please check permissions.'.format(exoctk_data_dir))
 
-    # Select the URLs and always include the log files
-    urls = DATA_URLS[tool]
-    urls += DATA_URLS['exoctk_log']
+    # Select packages without mutating DATA_URLS.  The log database is useful
+    # to the application and is included with every individual package.
+    if tool == 'all':
+        package_names = ['modelgrid', 'generic', 'fortney', 'groups_integrations', 'exoctk_contam', 'exoctk_log']
+    else:
+        package_names = [tool]
+        if tool != 'exoctk_log':
+            package_names.append('exoctk_log')
 
-    # Build landing paths for downloads
-    download_paths = [os.path.join(exoctk_data_dir, os.path.basename(url)) for url in urls]
+    archives = [(package_name, url)
+                for package_name in package_names
+                for url in DATA_URLS[package_name]]
+    download_paths = []
 
     # Perform the downloads
-    for i, url in enumerate(urls):
+    for i, (package_name, url) in enumerate(archives):
         landing_path = os.path.join(exoctk_data_dir, os.path.basename(url))
-        print('({}/{}) Downloading data to {} from {}'.format(i + 1, len(urls), landing_path, url))
-        with requests.get(url, stream=True) as response:
-            with open(landing_path, 'wb') as f:
-                for chunk in response.iter_content(chunk_size=2048):
-                    if chunk:
-                        f.write(chunk)
+        download_paths.append(landing_path)
+        print('({}/{}) Downloading data to {} from {}'.format(i + 1, len(archives), landing_path, url))
+        try:
+            with requests.get(url, stream=True, timeout=60) as response:
+                response.raise_for_status()
+                with open(landing_path, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=2048):
+                        if chunk:
+                            f.write(chunk)
+        except requests.RequestException as exc:
+            if os.path.exists(landing_path):
+                os.remove(landing_path)
+            raise RuntimeError(f'Unable to download ExoCTK data from {url}: {exc}') from exc
     print('\nDownload complete\n')
 
     # Uncompress data
     print('Uncompressing data:\n')
     for path in download_paths:
-        # Uncompress data
         print('\t{}'.format(path))
-        shutil.unpack_archive(path, exoctk_data_dir)
-        # Remove original .tar.gz files
-        os.remove(path)
-
-    # Combine modelgrid directories
-    print('\nOrganizing files into exoctk_data/ directory')
-    try:
-        os.makedirs(os.path.join(exoctk_data_dir, 'modelgrid', 'ATLAS9'))
-        os.makedirs(os.path.join(exoctk_data_dir, 'modelgrid', 'ACES'))
-    except FileExistsError:
-        pass
-    modelgrid_files = glob.glob(os.path.join(exoctk_data_dir, 'modelgrid.*', '*'))
-    for src in modelgrid_files:
-        if 'ATLAS9' in src:
-            dst = os.path.join(exoctk_data_dir, 'modelgrid', 'ATLAS9')
-        elif 'ACES_' in src:
-            dst = os.path.join(exoctk_data_dir, 'modelgrid', 'ACES')
         try:
-            shutil.move(src, dst)
-        except shutil.Error:
-            print('Unable to organize modelgrid/ directory')
+            shutil.unpack_archive(path, exoctk_data_dir)
+        except (shutil.ReadError, ValueError) as exc:
+            raise RuntimeError(f'Downloaded ExoCTK data archive is invalid: {path}') from exc
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
 
-    for dir in ['modelgrid.ATLAS9', 'modelgrid.ACES_1', 'modelgrid.ACES_2']:
-        path = os.path.join(exoctk_data_dir, dir)
-        if os.path.exists(path):
-            shutil.rmtree(path)
+    # Model-grid archives extract into modelgrid.* directories.
+    legacy_modelgrid = glob.glob(os.path.join(exoctk_data_dir, 'modelgrid.*'))
+    if legacy_modelgrid:
+        print('\nOrganizing files into exoctk_data/ directory')
+        modelgrid_dir = os.path.join(exoctk_data_dir, 'modelgrid')
+        os.makedirs(modelgrid_dir, exist_ok=True)
+        for source in legacy_modelgrid:
+            if not os.path.isdir(source):
+                continue
+            name = os.path.basename(source)
+            if name == 'modelgrid.ATLAS9':
+                destination = os.path.join(modelgrid_dir, 'ATLAS9')
+            elif name.startswith('modelgrid.ACES_'):
+                destination = os.path.join(modelgrid_dir, 'ACES')
+            else:
+                continue
+            os.makedirs(destination, exist_ok=True)
+            for item in glob.glob(os.path.join(source, '*')):
+                try:
+                    shutil.move(item, destination)
+                except shutil.Error:
+                    print('Unable to organize modelgrid/ directory')
+            shutil.rmtree(source)
 
     print('Completed!')
 


### PR DESCRIPTION
## Summary

- replace obsolete ExoCTK data URLs with the v2026.7 archives under `data.science.stsci.edu/redirect/JWST/ExoCTK/exoctk_data_v2026p7/compressed/`
- download and extract the eight `.tar.gz` archives, including the three separate model-grid packages
- preserve safe package selection, HTTP response validation, cleanup, and model-grid organization
- make the Website Test build the ExoCTK image and invoke `download_exoctk_data("all")`, keeping CI on the same download and layout path as users
- add regression coverage for individual-package selection, archive filenames, and HTTP failures
- bound JPL Horizons requests and only permit packaged ephemeris fallback when it covers the full requested date range
- compute visibility positions once for both the plot and CSV output
- make Website Test detect internal-server-error pages case-insensitively and limit Selenium page loads to 150 seconds

## Testing

- `python -m pytest exoctk/tests/test_utils.py -k download_exoctk_data -q` (`2 passed`)
- `/Users/tbell/miniconda3/envs/exoctk_2026.7-rc1/bin/python -m pytest exoctk/tests/test_contam_visibility.py -k "test_new_vis_plot or bounded_ephemeris or build_visibility_plot_reuses" -q` (`4 passed`)
- workflow YAML parsed successfully
- `docker compose --project-directory docker config --quiet`
- `git diff --check`