### PR TITLE
Make ExoMAST lookup failures explicit and testable

### DIFF
--- a/exoctk/tests/test_utils.py
+++ b/exoctk/tests/test_utils.py
@@ -121,6 +121,35 @@ def test_get_canonical_name_identifies_service_outage(monkeypatch):
         get_canonical_name('not-a-target')
 
 
+@pytest.mark.parametrize('status_code', [429, 500, 503])
+def test_get_canonical_name_identifies_http_outage(
+        monkeypatch, status_code):
+    """Rate limits and server errors should be treated as temporary outages."""
+
+    response = requests.Response()
+    response.status_code = status_code
+    error = requests.HTTPError(
+        f'{status_code} response', response=response)
+    monkeypatch.setattr(
+        utils.requests, 'get',
+        lambda *args, **kwargs: MockResponse(None, error=error))
+
+    with pytest.raises(ExoMASTServiceUnavailableError, match='unavailable'):
+        get_canonical_name('not-a-target')
+
+
+def test_get_canonical_name_rejects_non_outage_request_error(monkeypatch):
+    """Client and integration errors must not masquerade as service outages."""
+
+    monkeypatch.setattr(
+        utils.requests, 'get',
+        lambda *args, **kwargs: MockResponse(
+            None, error=requests.TooManyRedirects('redirect loop')))
+
+    with pytest.raises(ExoMASTError, match='request failed'):
+        get_canonical_name('not-a-target')
+
+
 def test_get_canonical_name_wraps_invalid_json(monkeypatch):
     monkeypatch.setattr(
         utils.requests, 'get',

--- a/exoctk/tests/test_utils.py
+++ b/exoctk/tests/test_utils.py
@@ -25,7 +25,8 @@ import pytest
 import requests
 
 from exoctk import utils
-from exoctk.utils import (DATA_URLS, ExoMASTError, color_gen,
+from exoctk.utils import (DATA_URLS, ExoMASTError,
+                          ExoMASTServiceUnavailableError, color_gen,
                           download_exoctk_data, filter_table,
                           get_canonical_name, get_target_data, medfilt)
 
@@ -111,6 +112,15 @@ def test_get_canonical_name_wraps_request_errors(monkeypatch):
         get_canonical_name('not-a-target')
 
 
+def test_get_canonical_name_identifies_service_outage(monkeypatch):
+    monkeypatch.setattr(
+        utils.requests, 'get',
+        lambda *args, **kwargs: MockResponse(
+            None, error=requests.ConnectionError('connection refused')))
+    with pytest.raises(ExoMASTServiceUnavailableError, match='unavailable'):
+        get_canonical_name('not-a-target')
+
+
 def test_get_canonical_name_wraps_invalid_json(monkeypatch):
     monkeypatch.setattr(
         utils.requests, 'get',
@@ -129,6 +139,21 @@ def test_get_target_data_rejects_empty_response(monkeypatch):
     monkeypatch.setattr(utils.requests, 'get', mock_get)
     with pytest.raises(ExoMASTError, match='no usable target data'):
         get_target_data('HD108236f')
+
+
+@pytest.mark.integration
+def test_live_exomast_target_lookup_smoke():
+    """Verify the ExoMAST API still supplies the fields ExoCTK requires."""
+
+    try:
+        data, url = get_target_data('WASP-43b')
+    except ExoMASTServiceUnavailableError as exc:
+        pytest.xfail(f'ExoMAST is temporarily unavailable: {exc}')
+
+    assert isinstance(data['RA'], (int, float))
+    assert isinstance(data['DEC'], (int, float))
+    assert isinstance(data['Teff'], (int, float))
+    assert 'WASP43b' in url
 
 
 @pytest.fixture

--- a/exoctk/tests/test_utils.py
+++ b/exoctk/tests/test_utils.py
@@ -24,39 +24,111 @@ import numpy as np
 import pytest
 import requests
 
-from exoctk.utils import DATA_URLS, color_gen, download_exoctk_data, filter_table, get_canonical_name, get_target_data, medfilt
+from exoctk import utils
+from exoctk.utils import (DATA_URLS, ExoMASTError, color_gen,
+                          download_exoctk_data, filter_table,
+                          get_canonical_name, get_target_data, medfilt)
 
-ARGS = ['planet_name', 'planet_data']
-
-# Include 3 actual planets with data and one fake planet to xfail.
-TEST_DATA = [('HD108236f', {'canonical_name': 'HD 108236 f', 'Fe/H': -0.28, 'Teff': 5660.0, 'stellar_gravity': 4.49, 'transit_duration': 0.13625, 'RA': 186.5740627, 'DEC': -51.3630519}),
-             ('NGTS-14Ab', {'canonical_name': 'NGTS-14 A b', 'Fe/H': 0.1, 'Teff': 5187.0, 'stellar_gravity': 4.2, 'transit_duration': 0.09333333333333334, 'RA': 328.5174799, 'DEC': -38.3774193}),
-             ('2MASSJ10193800-0948225b', {'canonical_name': 'WASP-43 b', 'Fe/H': -0.05, 'Teff': 4400.0, 'stellar_gravity': 4.49, 'transit_duration': 0.0513, 'RA': 154.9081869, 'DEC': -9.8064431}),
-             pytest.param('djgfjhsg', {'canonical_name': 'sfghsfkjg', 'Fe/H': -999, 'Teff': -999, 'stellar_gravity': -999, 'transit_duration': -999, 'RA': -999, 'DEC': -999}, marks=pytest.mark.xfail)]
+TEST_TARGET = {
+    'canonical_name': 'HD 108236 f',
+    'Fe/H': -0.28,
+    'Teff': 5660.0,
+    'stellar_gravity': 4.49,
+    'transit_duration': 0.13625,
+    'RA': 186.5740627,
+    'DEC': -51.3630519,
+}
 
 MEDFILT_DATA = [(np.array([1, 1, 8, 12, 2, 10, 5, 2, 5, 2]), 4),
                 (np.array([1, 1, 8, 12, 2, 10, 5, 2, 5, 2]), 4)]
 
 
-@pytest.mark.parametrize(ARGS, TEST_DATA)
-def test_get_canoical_name(planet_name, planet_data):
-    """Test that the canonical name of the planet is returned by exomast"""
+class MockResponse:
+    """Minimal requests response used to test ExoMAST handling."""
 
-    canonical_name = get_canonical_name(planet_name)
-    assert canonical_name == planet_data['canonical_name']
+    def __init__(self, payload, error=None, json_error=None):
+        self.payload = payload
+        self.error = error
+        self.json_error = json_error
+
+    def raise_for_status(self):
+        if self.error is not None:
+            raise self.error
+
+    def json(self):
+        if self.json_error is not None:
+            raise self.json_error
+        return self.payload
 
 
-@pytest.mark.parametrize(ARGS, TEST_DATA)
-def test_get_target_data(planet_name, planet_data):
-    """Test that the canonical name of the planet is returned by exomast"""
+def test_get_canonical_name_uses_valid_exomast_response(monkeypatch):
+    """Canonical-name lookup should parse a successful ExoMAST response."""
 
-    data, _ = get_target_data(planet_name)
+    calls = []
 
-    # these are some params that the webapp uses for it's tools
-    exomast_params = ['Fe/H', 'Teff', 'stellar_gravity', 'transit_duration', 'RA', 'DEC']
+    def mock_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return MockResponse({'canonicalName': TEST_TARGET['canonical_name']})
 
-    for value in exomast_params:
-        assert data[value] == pytest.approx(planet_data[value], 0.1)
+    monkeypatch.setattr(utils.requests, 'get', mock_get)
+    assert get_canonical_name('HD108236f') == TEST_TARGET['canonical_name']
+    assert calls[0][1]['params'] == {'name': 'HD108236f'}
+    assert calls[0][1]['timeout'] == utils.EXOMAST_TIMEOUT_SECONDS
+
+
+def test_get_target_data_prefers_nexsci_catalog(monkeypatch):
+    """Target lookup should use the preferred catalog from valid responses."""
+
+    def mock_get(url, **kwargs):
+        if 'identifiers' in url:
+            return MockResponse(
+                {'canonicalName': TEST_TARGET['canonical_name']})
+        alternate = dict(TEST_TARGET, catalog_name='other', Teff=5000.)
+        preferred = dict(TEST_TARGET, catalog_name='nexsci')
+        return MockResponse([alternate, preferred])
+
+    monkeypatch.setattr(utils.requests, 'get', mock_get)
+    data, url = get_target_data('HD108236f')
+    assert data['catalog_name'] == 'nexsci'
+    assert data['Teff'] == pytest.approx(TEST_TARGET['Teff'])
+    assert TEST_TARGET['canonical_name'].replace(' ', '') in url
+
+
+@pytest.mark.parametrize('payload', [{}, None, []])
+def test_get_canonical_name_rejects_malformed_response(monkeypatch, payload):
+    monkeypatch.setattr(
+        utils.requests, 'get', lambda *args, **kwargs: MockResponse(payload))
+    with pytest.raises(ExoMASTError, match='no canonical name'):
+        get_canonical_name('not-a-target')
+
+
+def test_get_canonical_name_wraps_request_errors(monkeypatch):
+    monkeypatch.setattr(
+        utils.requests, 'get',
+        lambda *args, **kwargs: MockResponse(
+            None, error=requests.HTTPError('404 Client Error')))
+    with pytest.raises(ExoMASTError, match='request failed'):
+        get_canonical_name('not-a-target')
+
+
+def test_get_canonical_name_wraps_invalid_json(monkeypatch):
+    monkeypatch.setattr(
+        utils.requests, 'get',
+        lambda *args, **kwargs: MockResponse(None, json_error=ValueError()))
+    with pytest.raises(ExoMASTError, match='invalid JSON'):
+        get_canonical_name('not-a-target')
+
+
+def test_get_target_data_rejects_empty_response(monkeypatch):
+    def mock_get(url, **kwargs):
+        if 'identifiers' in url:
+            return MockResponse(
+                {'canonicalName': TEST_TARGET['canonical_name']})
+        return MockResponse([])
+
+    monkeypatch.setattr(utils.requests, 'get', mock_get)
+    with pytest.raises(ExoMASTError, match='no usable target data'):
+        get_target_data('HD108236f')
 
 
 @pytest.fixture

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -27,6 +27,10 @@ class ExoMASTError(RuntimeError):
     """Raised when ExoMAST cannot provide usable target information."""
 
 
+class ExoMASTServiceUnavailableError(ExoMASTError):
+    """Raised when ExoMAST is temporarily unavailable."""
+
+
 EXOMAST_TIMEOUT_SECONDS = 30
 
 try:
@@ -796,8 +800,19 @@ def _get_exomast_json(url, params=None):
         response = requests.get(
             url, params=params, timeout=EXOMAST_TIMEOUT_SECONDS)
         response.raise_for_status()
-    except requests.RequestException as exc:
+    except (requests.ConnectionError, requests.Timeout) as exc:
+        raise ExoMASTServiceUnavailableError(
+            f'ExoMAST is unavailable: {exc}') from exc
+    except requests.HTTPError as exc:
+        status_code = getattr(exc.response, 'status_code', None)
+        if status_code == 429 or (status_code is not None and
+                                  status_code >= 500):
+            raise ExoMASTServiceUnavailableError(
+                f'ExoMAST is unavailable: {exc}') from exc
         raise ExoMASTError(f'ExoMAST request failed: {exc}') from exc
+    except requests.RequestException as exc:
+        raise ExoMASTServiceUnavailableError(
+            f'ExoMAST is unavailable: {exc}') from exc
 
     try:
         return response.json()

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -811,8 +811,7 @@ def _get_exomast_json(url, params=None):
                 f'ExoMAST is unavailable: {exc}') from exc
         raise ExoMASTError(f'ExoMAST request failed: {exc}') from exc
     except requests.RequestException as exc:
-        raise ExoMASTServiceUnavailableError(
-            f'ExoMAST is unavailable: {exc}') from exc
+        raise ExoMASTError(f'ExoMAST request failed: {exc}') from exc
 
     try:
         return response.json()

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -23,6 +23,12 @@ import numpy as np
 from svo_filters import svo
 from bokeh.plotting import figure, show
 
+class ExoMASTError(RuntimeError):
+    """Raised when ExoMAST cannot provide usable target information."""
+
+
+EXOMAST_TIMEOUT_SECONDS = 30
+
 try:
     from .throughputs import JWST_THROUGHPUTS
 
@@ -681,9 +687,12 @@ def get_canonical_name(target_name):
     # Create params dict for url parsing. Easier than trying to format yourself.
     params = {"name": target_name}
 
-    r = requests.get(target_url, params=params)
-    planetnames = r.json()
-    canonical_name = planetnames['canonicalName']
+    planetnames = _get_exomast_json(target_url, params=params)
+    canonical_name = planetnames.get('canonicalName') if isinstance(
+        planetnames, dict) else None
+    if not isinstance(canonical_name, str) or not canonical_name.strip():
+        raise ExoMASTError(
+            f"ExoMAST returned no canonical name for '{target_name}'.")
 
     return canonical_name
 
@@ -751,12 +760,11 @@ def get_target_data(target_name):
 
     target_url = build_target_url(canonical_name)
 
-    r = requests.get(target_url)
-
-    if r.status_code == 200:
-        target_data = r.json()
-    else:
-        print('Whoops, no data for this target!')
+    target_data = _get_exomast_json(target_url)
+    if (not isinstance(target_data, list) or not target_data or
+            not all(isinstance(entry, dict) for entry in target_data)):
+        raise ExoMASTError(
+            f"ExoMAST returned no usable target data for '{canonical_name}'.")
 
     # Some targets have multiple catalogs
     # nexsci is the first choice.
@@ -779,6 +787,22 @@ def get_target_data(target_name):
     url = 'https://exo.mast.stsci.edu/exomast_planet.html?planet={}'.format(re.sub(r'\W+', '', canonical_name))
 
     return target_data, url
+
+
+def _get_exomast_json(url, params=None):
+    """Request and validate a JSON payload from an ExoMAST endpoint."""
+
+    try:
+        response = requests.get(
+            url, params=params, timeout=EXOMAST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise ExoMASTError(f'ExoMAST request failed: {exc}') from exc
+
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise ExoMASTError('ExoMAST returned an invalid JSON response.') from exc
 
 
 def interp_flux(mu, flux, params, values):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,6 @@ namespaces = false
 
 [tool.pytest]
 junit_family = "xunit2"
+markers = [
+  "integration: test requiring a live external service",
+]


### PR DESCRIPTION
Closes #715

This PR hardens ExoMAST target lookups and replaces live-service-dependent expected-failure tests with deterministic unit coverage.

Changes:
- Add bounded ExoMAST requests with HTTP-status and JSON validation.
- Raise clear exceptions for malformed responses, unknown targets, and unusable target-data payloads.
- Distinguish temporary ExoMAST outages from client-side integration failures.
- Replace the former live XFAIL tests with mocked unit tests.
- Add a live ExoMAST smoke test to the normal suite. It soft-fails only for temporary availability failures such as DNS, connection, timeout, rate-limit, and 5xx errors; response-contract failures remain hard failures.

Testing:
- pytest exoctk/tests/test_utils.py -q -rxX
- Result in my local environment: `19 passed in 4.74s`