### PR TITLE
Suppress expected jwst_gtvt future-date ERFA warnings locally

### DIFF
--- a/exoctk/contam_visibility/new_vis_plot.py
+++ b/exoctk/contam_visibility/new_vis_plot.py
@@ -147,8 +147,8 @@ def get_exoplanet_positions(ra, dec, in_FOR=None):
         dec = dec[:-1]
 
     # jwst_gtvt validates its future maximum date during construction, which
-    # can emit an ERFA warning about uncertain leap seconds. Keep this
-    # suppression local so other ERFA warnings remain visible to callers.
+    # can emit ERFA's expected "dubious year" warning. Keep this suppression
+    # local so other ERFA warnings remain visible to callers.
     with warnings.catch_warnings():
         warnings.filterwarnings(
             'ignore',

--- a/exoctk/contam_visibility/new_vis_plot.py
+++ b/exoctk/contam_visibility/new_vis_plot.py
@@ -4,6 +4,7 @@ import re
 import warnings
 
 from astropy.time import Time
+from erfa import ErfaWarning
 
 from bokeh.models import Band, ColumnDataSource, HoverTool
 from bokeh.plotting import figure, show
@@ -145,7 +146,17 @@ def get_exoplanet_positions(ra, dec, in_FOR=None):
     while dec[-1] not in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.']:
         dec = dec[:-1]
 
-    eph = BoundedEphemeris()
+    # jwst_gtvt validates its future maximum date during construction, which
+    # can emit an ERFA warning about uncertain leap seconds. Keep this
+    # suppression local so other ERFA warnings remain visible to callers.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            message=(r'ERFA function "dtf2d" yielded .*'
+                     r'"dubious year \(Note 6\)"'),
+            category=ErfaWarning,
+        )
+        eph = BoundedEphemeris()
     exoplanet_data = eph.get_fixed_target_positions(ra, dec)
 
     if in_FOR is None:

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -240,12 +240,13 @@ def test_visibility_ephemeris_suppresses_only_expected_erfa_warning(monkeypatch)
 
     monkeypatch.setattr(new_vis_plot, 'BoundedEphemeris', WarningEphemeris)
     with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter('always')
+        warnings.simplefilter('ignore')
+        warnings.simplefilter('always', ErfaWarning)
         result = new_vis_plot.get_exoplanet_positions('24.3544618',
                                                        '-45.6777937')
 
     assert isinstance(result, DataFrame)
-    assert [str(warning.message) for warning in caught] == [
+    assert [str(w.message) for w in caught] == [
         'unrelated ERFA warning']
 
 

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -34,6 +34,7 @@ import numpy as np
 import pytest
 import pysiaf
 import requests
+from erfa import ErfaWarning
 
 from pandas import DataFrame
 from astropy.io import fits
@@ -221,6 +222,31 @@ def test_build_visibility_plot_reuses_positions(monkeypatch):
 
     assert str(type(plot)) == "<class 'bokeh.plotting._figure.figure'>"
     assert 'times' not in positions
+
+
+def test_visibility_ephemeris_suppresses_only_expected_erfa_warning(monkeypatch):
+    """The jwst_gtvt future-date warning must not hide other warnings."""
+
+    class WarningEphemeris:
+        def __init__(self, *args, **kwargs):
+            warnings.warn(
+                'ERFA function "dtf2d" yielded 1 of "dubious year (Note 6)"',
+                ErfaWarning,
+            )
+            warnings.warn('unrelated ERFA warning', ErfaWarning)
+
+        def get_fixed_target_positions(self, ra, dec):
+            return DataFrame({'in_FOR': [True]})
+
+    monkeypatch.setattr(new_vis_plot, 'BoundedEphemeris', WarningEphemeris)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        result = new_vis_plot.get_exoplanet_positions('24.3544618',
+                                                       '-45.6777937')
+
+    assert isinstance(result, DataFrame)
+    assert [str(warning.message) for warning in caught] == [
+        'unrelated ERFA warning']
 
 
 @pytest.mark.skipif(ON_GITHUB_ACTIONS, reason='Need access to trace data FITS files.  Please try running locally')


### PR DESCRIPTION
Closes #716

jwst_gtvt validates its internal future maximum date while constructing an ephemeris, producing an ERFA `dubious year` warning even when the requested visibility period is earlier.

This change suppresses only that expected warning, only during ephemeris construction. A regression test verifies that unrelated ERFA warnings remain visible.

Tests: `pytest exoctk/tests/test_contam_visibility.py -q -k 'new_vis_plot or visibility_ephemeris_suppresses'`