### PR TITLE
Harden source flux validation and empty-channel handling

### DIFF
--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -47,9 +47,6 @@ from .new_vis_plot import build_visibility_plot, get_exoplanet_positions
 from .precompute import save_exoplanet_data
 from . import contamination_figure as cf
 
-import warnings
-warnings.filterwarnings("ignore", message="Mean of empty slice")
-
 log_file = 'contam_tool.log'
 logging.basicConfig(
     filename=log_file,
@@ -494,6 +491,36 @@ def _target_source_index(stars, target_coordinate, input_epoch=2000):
     return int(np.argmin(target_coordinate.separation(catalog_at_input_epoch)))
 
 
+def _finite_positive_scalar(value):
+    """Return a finite positive float, or ``None`` for unusable values."""
+
+    if np.ma.is_masked(value):
+        return None
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return None
+    return value if np.isfinite(value) and value > 0 else None
+
+
+def _filter_valid_flux_sources(stars, column, label):
+    """Retain sources with usable fluxes, requiring a usable target flux."""
+
+    if column not in stars.colnames:
+        raise ValueError(f'Source table is missing the {label} column.')
+
+    valid_flux = np.array([
+        _finite_positive_scalar(value) is not None for value in stars[column]
+    ])
+    if not len(valid_flux) or not valid_flux[0]:
+        raise ValueError(f'The identified target does not have a valid {label}.')
+
+    rejected = np.count_nonzero(~valid_flux)
+    if rejected:
+        logging.info('Ignoring %d sources without valid %s.', rejected, label)
+    return stars[valid_flux]
+
+
 def find_sources(ra=None, dec=None, target=None, width=7.5*u.arcmin, target_date=None, verbose=False, pm_corr=True, plot=False):
     """
     Find all the stars in the vicinity and estimate temperatures
@@ -544,6 +571,12 @@ def find_sources(ra=None, dec=None, target=None, width=7.5*u.arcmin, target_date
     order = np.concatenate(([target_index], np.delete(
         np.arange(len(stars)), target_index)))
     stars = stars[order]
+
+    # Sources without measured Gaia G fluxes cannot be normalized. In
+    # particular, masked values must not reach the detector arithmetic, where
+    # their underlying data could be treated as a valid flux scale.
+    stars = _filter_valid_flux_sources(
+        stars, 'phot_g_mean_flux', 'Gaia G-band flux')
 
     try:
         # Perform XMatch between Gaia and SDSS DR16
@@ -813,8 +846,16 @@ def fraction_contaminated(aperture, targframes, starcube):
     pctlines = []
     for i, (pframe, mask) in enumerate(zip(pctframes, trace_masks)):
         masked = pframe * mask
-        with np.errstate(invalid='ignore', divide='ignore'):
-            mean_line = np.nanmean(masked, axis=1)
+        # Keep empty spectral channels as NaN, but avoid NumPy's repeated
+        # ``Mean of empty slice`` warnings for the expected empty channels.
+        valid = ~np.isnan(masked)
+        numerator = np.nansum(masked, axis=1)
+        denominator = np.sum(valid, axis=1)
+        mean_line = np.divide(
+            numerator, denominator,
+            out=np.full(np.shape(numerator), np.nan, dtype=float),
+            where=denominator > 0,
+        )
         pctlines.append(mean_line)
 
     return pctlines
@@ -957,6 +998,11 @@ def calc_v3pa(V3PA, stars, aperture, data=None, tilt=0, plot=False, POM=False):
     lft, rgt, top, bot = aper['lft'], aper['rgt'], aper['top'], aper['bot']
     FOVstars = stars[(lft < stars['xord0']) & (stars['xord0'] < rgt) & (bot < stars['yord0']) & (stars['yord0'] < top)]
 
+    # ``find_sources`` filters Gaia results, but callers may pass a custom
+    # table straight to this renderer. Apply the same validation at this
+    # boundary before multiplying detector traces by ``fluxscale``.
+    FOVstars = _filter_valid_flux_sources(FOVstars, 'fluxscale', 'flux scale')
+
     # Get the traces for sources in the FOV and add the column to the source table
     star_traces = [get_trace(aperture.AperName, temp, typ) for temp, typ in zip(FOVstars['Teff'], FOVstars['type'])]
     FOVstars['traces'] = star_traces
@@ -976,7 +1022,8 @@ def calc_v3pa(V3PA, stars, aperture, data=None, tilt=0, plot=False, POM=False):
     for idx, star in enumerate(FOVstars):
 
         # Scale the traces for this source
-        traces = [trace * star['fluxscale'] * aper['empirical_scale'][n + 1] for n, trace in enumerate(star['traces'])]
+        fluxscale = float(star['fluxscale'])
+        traces = [trace * fluxscale * aper['empirical_scale'][n + 1] for n, trace in enumerate(star['traces'])]
 
         # Add each target trace to it's own frame
         if idx == 0:
@@ -993,7 +1040,7 @@ def calc_v3pa(V3PA, stars, aperture, data=None, tilt=0, plot=False, POM=False):
             order0 = get_order0(aperture.AperName, star['Teff'], stype=star['type']) * 1.5e3  # Scaling factor based on observations
 
             # Scale the order 0 image and add it to the starframe
-            scale0 = copy(order0) * star['fluxscale'] * aper['empirical_scale'][0]
+            scale0 = copy(order0) * fluxscale * aper['empirical_scale'][0]
             starframe = add_array_at_position(starframe, scale0, int(star['xord0'] - aper['subarr_x'][0]), int(star['yord0'] - aper['subarr_y'][1]), centered=True)
 
             # NOTE: Take this conditional out if you want to see galaxy traces!

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -22,13 +22,14 @@ Use
 
 import os
 import sys
+import warnings
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 from pandas import DataFrame
-from astropy.table import Table
+from astropy.table import MaskedColumn, Table
 import astropy.units as u
 
 from exoctk.contam_visibility import field_simulator
@@ -331,6 +332,76 @@ def test_contamination_slider_uses_percent_and_common_display_cap():
     assert np.all(line_renderer.data_source.data['contam1'] == 12.5)
     assert shading_renderer.data_source.data['top'][0] == 10
     assert threshold_renderer.data_source.data['top'][0] == 10
+
+
+def test_find_sources_ignores_invalid_gaia_fluxes(monkeypatch):
+    """Invalid Gaia G fluxes cannot become normalized field sources."""
+
+    stars = Table({
+        'source_id': [1, 2, 3, 4, 5, 6],
+        'ra': [10., 10.001, 10.002, 10.003, 10.004, 10.005],
+        'dec': [20., 20., 20., 20., 20., 20.],
+        'pmra': [0.] * 6,
+        'pmdec': [0.] * 6,
+        'ref_epoch': [2016.] * 6,
+        'bp_rp': [1.] * 6,
+        'parallax': [1.] * 6,
+        'astrometric_excess_noise': [0.] * 6,
+        'phot_bp_rp_excess_factor': [1.] * 6,
+    })
+    stars['phot_g_mean_flux'] = MaskedColumn(
+        [1000., 1., 0., -1., np.nan, np.inf],
+        mask=[False, True, False, False, False, False])
+    monkeypatch.setattr(
+        field_simulator.GAIA_TAP, 'query_region',
+        lambda *args, **kwargs: stars.copy())
+    monkeypatch.setattr(
+        field_simulator.XMatch, 'query',
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError()))
+
+    result = field_simulator.find_sources(10., 20., target_date=2026)
+
+    assert list(result['source_id']) == [1]
+    assert result['fluxscale'][0] == pytest.approx(1.)
+
+
+def test_custom_source_flux_validation_rejects_invalid_target_and_sources():
+    """The rendering boundary validates direct custom source tables."""
+
+    sources = Table()
+    sources['fluxscale'] = MaskedColumn(
+        [1., 1., 0., -1., np.nan, np.inf],
+        mask=[False, True, False, False, False, False])
+    filtered = field_simulator._filter_valid_flux_sources(
+        sources, 'fluxscale', 'flux scale')
+    assert len(filtered) == 1
+    assert filtered['fluxscale'][0] == pytest.approx(1.)
+
+    sources['fluxscale'][0] = 0.
+    with pytest.raises(ValueError, match='target does not have a valid flux scale'):
+        field_simulator._filter_valid_flux_sources(
+            sources, 'fluxscale', 'flux scale')
+
+
+def test_fraction_contaminated_returns_nan_for_empty_channel_without_warning(
+        monkeypatch):
+    """Expected empty extraction channels do not globally hide warnings."""
+
+    target = np.array([[1., 0.], [1., 0.]])
+    contaminants = np.zeros((1, 2, 2))
+    monkeypatch.setattr(
+        field_simulator, 'NIRISS_SOSS_trace_mask',
+        lambda aperture: [np.ones_like(target)])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        result = field_simulator.fraction_contaminated(
+            'NIS_SUBSTRIP256', [target], contaminants)[0]
+
+    assert result.shape == (1, 2)
+    assert np.allclose(result[:, 0], 0.)
+    assert np.isnan(result[:, 1]).all()
+    assert not any('Mean of empty slice' in str(warning.message)
+                   for warning in caught)
 
 
 @pytest.mark.parametrize('aperture', [


### PR DESCRIPTION
Closes #711

This PR hardens the shared contamination calculations against invalid source fluxes and expected empty spectral channels.

Changes:
- Require the identified target to have a finite, positive Gaia G-band flux.
- Exclude neighboring sources with masked, zero, negative, or non-finite G-band fluxes before normalization.
- Apply equivalent validation to caller-supplied source tables before detector rendering.
- Replace the global `Mean of empty slice` warning suppression with an explicit NaN-preserving reduction.
- Add regression coverage for invalid target/source fluxes and empty spectral channels.

Invalid target fluxes raise a clear error; invalid neighboring sources are omitted and logged.

Tests:
`pytest exoctk/tests/test_contam_visibility.py -q -k 'find_sources or custom_source_flux or fraction_contaminated_returns'`