### PR TITLE
Improve contamination plot readability and guidance

### DIFF
--- a/exoctk/contam_visibility/contamination_figure.py
+++ b/exoctk/contam_visibility/contamination_figure.py
@@ -37,7 +37,7 @@ lam0_nircam444w = 3.063
 lam1_nircam444w = 5.111
 
 
-def contam_slider_plot(pctlines, badPA_list, threshold=0.05):
+def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1):
     """
     Make the contamination plot with a slider
 
@@ -49,6 +49,9 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05):
         The position angles that are not observable
     threshold: float
         The threshold for contamination reporting in the plot
+    y_max: float
+        The fractional contamination at the top of both displayed axes. Values
+        above this limit remain in the data and are clipped only visually.
 
     Returns
     -------
@@ -59,12 +62,16 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05):
     pa_list = np.arange(360)
     orders = np.arange(1, len(pctlines)+1)
     n_channels = pctlines[0].shape[1]
+    if not 0 < y_max <= 1:
+        raise ValueError('y_max must be greater than zero and at most one')
+    percent_lines = [np.asarray(line) * 100 for line in pctlines]
+    display_y_max = y_max * 100
 
     # Store individual contamination fractions for each order+PA combination
     contam_dict = {}
     for order in orders:
-        for pa, frac in enumerate(pctlines[order - 1]):
-            contam_dict[f'contam{order}_{pa}'] = frac
+        for pa, percent in enumerate(percent_lines[order - 1]):
+            contam_dict[f'contam{order}_{pa}'] = percent
 
     # Choose initial values and build visible and available dicts
     pa_init = int(np.argmax(np.nansum(np.asarray(pctlines), axis=(0, 2)))) # Maximum contamination
@@ -81,11 +88,11 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05):
         glyph = VArea(x="col", y1="zeros", y2=f"contam{order}", fill_color=colors[order - 1], fill_alpha=0.3)
         plt.add_glyph(source_visible, glyph)
 
-    plt.y_range = Range1d(0, 1)
+    plt.y_range = Range1d(0, display_y_max)
     plt.x_range = Range1d(0, n_channels)
     plt.xaxis.axis_label = 'Column Index'
-    plt.yaxis.axis_label = 'Contamination / Target Flux'
-    slider = Slider(title='Position Angle',
+    plt.yaxis.axis_label = 'Contamination (%)'
+    slider = Slider(title='V3 Position Angle',
                     value=pa_init,
                     start=min(pa_list),
                     end=max(pa_list),
@@ -107,7 +114,8 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05):
         """)
 
     # Make a guide that shows which PAs are unobservable
-    viz_none = np.array([1 if i in badPA_list else 0 for i in pa_list])
+    viz_none = np.array([
+        display_y_max if i in badPA_list else 0 for i in pa_list])
     viz_plt = figure(width=900, height=300, x_range=Range1d(0, 359))
     c0 = viz_plt.vbar(x=np.arange(360), top=viz_none, width=1.1, alpha=0.5, line_color=None, fill_color='#555555')
 
@@ -115,21 +123,24 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05):
     vis_ords = []
     for order in orders:
 
-        # Plot step to show maximum contamination per channel
-        viz_plt.step(pa_list, np.nanmean(pctlines[order - 1], axis=1), line_width=2, color=colors[order - 1], mode="center")
+        # Plot the mean contamination across spectral channels.
+        viz_plt.step(pa_list, np.nanmean(percent_lines[order - 1], axis=1), line_width=2, color=colors[order - 1], mode="center")
 
         # PLot columns that indicate >5% contamination
-        viz_ord = np.array([1 if i > threshold else 0 for i in np.nanmax(pctlines[order - 1], axis=1)])
+        viz_ord = np.array([
+            display_y_max if value > threshold else 0
+            for value in np.nanmax(pctlines[order - 1], axis=1)
+        ])
         vis_ords.append(viz_plt.vbar(x=pa_list, top=viz_ord, width=1.1, alpha=0.2, line_color=None, fill_color=colors[order - 1]))
 
     # Formatting
     viz_plt.x_range = Range1d(0, 359)
-    viz_plt.y_range = Range1d(0, 1)
-    viz_plt.xaxis.axis_label = 'Position Angle'
-    viz_plt.yaxis.axis_label = 'Max(Contamination / Target Flux)'
+    viz_plt.y_range = Range1d(0, display_y_max)
+    viz_plt.xaxis.axis_label = 'V3 Position Angle'
+    viz_plt.yaxis.axis_label = 'Mean Contamination (%)'
     viz_plt.add_layout(span)
 
-    items = [("Target not visible", [c0])]
+    items = [("Target not observable", [c0])]
     for order, vis_ord in zip(orders, vis_ords):
         items.append((f'Ord {order} > {threshold * 100}% Contaminated', [vis_ord]))
     legend = Legend(items=items, location=(50, 0), orientation='horizontal', border_line_alpha=0)

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -688,13 +688,14 @@ def contam_visibility():
             badPAs = [pa for pa in np.arange(0, 360) if pa not in results]
             print("Made PA list")
 
-            if 'DHS' in form.inst.data:
+            if fs.contamination_supported(form.inst.data):
                 pctlines = fs.fraction_contaminated(
                     form.inst.data, targframe, starcube)
                 contam_plot = cf.contam_slider_plot(pctlines, badPAs)
-                print("Made DHS contamination plot")
+                print("Made contamination slider plot")
             else:
-                # Make legacy SOSS contamination plot
+                # Retain the legacy image plot for any future mode that has not
+                # adopted the common contamination-slider representation.
                 starcube_targ = np.zeros(
                     (362, 2048,
                      96 if form.inst.data == 'NIS_SUBSTRIP96' else 256))

--- a/exoctk/exoctk_app/templates/contam_visibility.html
+++ b/exoctk/exoctk_app/templates/contam_visibility.html
@@ -69,18 +69,15 @@
     <br>
 
 
-    	<p>This tool is designed for the slitless observation modes of all JWST instruments.
-    	For slitless observations, the spectrum of a target star may be contaminated by partially overlapping spectra of
-    	nearby stars. For a given target, this contamination depends on the
-    	position angle (PA) at which the observations are taken. This tool simulates NIRISS SOSS observations of a
-    	given target, and produces an estimate of the level of contamination as a function of the PA of the
-    	observation, thus making it useful to plan observations at the optimal PA. The tool also computes the JWST
-    	accessibility windows of the target, along with the corresponding accessible PAs for the chosen instrument/observation mode.
+	<p>This tool estimates contamination from neighboring sources for supported JWST slitless modes.
+	For slitless observations, a target spectrum can overlap partially with spectra from nearby sources. The amount
+	of overlap depends on the telescope orientation. The calculator evaluates contamination as a function of V3
+	position angle and computes the target's JWST visibility windows and corresponding aperture position angles.
       </p>
 
       <p>Potential caveats:</p>
       <ul>
-        <li>The field stars used for this analysis are retrieved from the Gaia EDR3 point source catalogue. Contamination from stars missing from this catalog are thus not modelled; this may be important for faint targets.</li>
+        <li>Field sources are retrieved from the Gaia DR3 point-source catalogue. Coordinates are propagated from each source's Gaia reference epoch to the requested observation epoch when proper-motion measurements are available. Sources absent from Gaia are not modelled.</li>
         <li>Distortion has been observed to create a trace offset as large as ~4 to 5 pixels in both the X and Y direction in the science frame which may contribute to uncertainty in the contamination plots.</li>
       </ul>
       <p>If there are any questions regarding these caveats please send us a ticket through the JWST help desk and we will get back to you shortly.</p>

--- a/exoctk/exoctk_app/templates/contam_visibility_results.html
+++ b/exoctk/exoctk_app/templates/contam_visibility_results.html
@@ -14,13 +14,10 @@
         <br>
 
 
-        <p>This tool is designed for the slitless observation modes of all JWST instruments.
-      	For slitless observations, the spectrum of a target star may be contaminated by partially overlapping spectra of
-      	nearby stars. For a given target, this contamination depends on the
-      	position angle (PA) at which the observations are taken. This tool simulates NIRISS SOSS observations of a
-      	given target, and produces an estimate of the level of contamination as a function of the PA of the
-      	observation, thus making it useful to plan observations at the optimal PA. The tool also computes the JWST
-      	accessibility windows of the target, along with the corresponding accessible PAs for the chosen instrument/observation mode.
+        <p>This tool estimates contamination from neighboring sources for supported JWST slitless modes.
+        For slitless observations, a target spectrum can overlap partially with spectra from nearby sources. The amount
+        of overlap depends on the telescope orientation. The calculator evaluates contamination as a function of V3
+        position angle and computes the target's JWST visibility windows and corresponding aperture position angles.
         </p>
 <!--        <p>-->
 <!--          <b>NIRCam and MIRI options</b>: Users can calculate contamination levels for NIRCam Grism Time Series (F322W2, F444W) and MIRI Low Resolution-->
@@ -30,7 +27,7 @@
 <!--        	</p>-->
         <p>Potential caveats:</p>
         <ul>
-          <li>The field stars used for this analysis are retrieved from the Gaia EDR3 point source catalogue, so all sources use epoch 2016.0 coordinates. Contamination from stars missing from this catalog is thus not modelled; this may be important for faint targets.</li>
+          <li>Field sources are retrieved from the Gaia DR3 point-source catalogue. Coordinates are propagated from each source's Gaia reference epoch to the requested observation epoch when proper-motion measurements are available. Sources absent from Gaia are not modelled.</li>
           <li>Distortion has been observed to create a trace offset as large as ~4 to 5 pixels in both the X and Y direction in the science frame which may contribute to uncertainty in the contamination plots.</li>
 <!--          <li>Traces on the MIRI detector may fold over below 4.5 microns. Our model traces assume no spectral foldover. Depending on the observation, this may lead to inaccurate results.</li>-->
         </ul>
@@ -74,26 +71,12 @@
     		<p>
                 {% if pa_val == -1 %}
                     <ul>
-                        <li>The larger panel shows, for each order, the contamination of the target star's spectrum due to orders 1 and 2 of its neighboring stars.</li>
-                        <li>The color scale denotes the contamination level (see scale below plot).</li>
-                        <li>The contamination level is defined as the ratio of the extracted flux coming from all field stars over the extracted flux coming from the target star, using the proper extraction weighing function for the target trace.</li>
-                        <li>The smaller panel shows, for each order, the fraction of all spectral channels that are contaminated at a level of at least 0.01 (green) or 0.001 (blue).</li>
-                        <li>The grey semi-transparent regions are the PAs that are inaccessible at the target RA & DEC.</li>
+                        <li>The upper panel shows contamination across the reported spectral channels at the V3 position angle selected with the slider.</li>
+                        <li>The lower curve shows the mean contamination across those channels at each V3 position angle. Shaded intervals identify angles where at least one channel exceeds the stated contamination threshold.</li>
+                        <li>Contamination is reported as the contaminant fraction, C/(T+C), evaluated from the target extraction region.</li>
+                        <li>Both axes are displayed from 0% to 10% to make low contamination easier to assess. Values above 10% are retained but clipped by the displayed range.</li>
+                        <li>Grey regions mark V3 position angles at which the target is not observable during the selected epoch.</li>
                     </ul>
-                    <div style="border:1px solid black; width:164px; height:21px;">
-                        <div style="border:none; width:20px; height:20px; background-color:#ffffff; float:left;"></div>
-                        <div style="border:none; width:20px; height:20px; background-color:#d0d1e6; float:left;"></div>
-                        <div style="border:none; width:20px; height:20px; background-color:#a6bddb; float:left;"></div>
-                        <div style="border:none; width:20px; height:20px; background-color:#74a9cf; float:left;"></div>
-                        <div style="border:none; width:20px; height:20px; background-color:#3690c0; float:left;"></div>
-                        <div style="border:none; width:20px; height:20px; background-color:#0570b0; float:left;"></div>
-                        <div style="border:none; width:20px; height:20px; background-color:#034e7b; float:left;"></div>
-                        <div style="border:none; width:20px; height:20px; background-color:#000000; float:left;"></div>
-                    </div>
-                    <div style="width:164px; height:22px; text-align:center;">
-                    -4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</div>
-                    <div style="width:164px; height:22px; text-align:center;">
-                    good&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bad</div>
                     <br><br>
 <!--                    <ul>-->
 <!--                        <li>The top plot shows the fractional contamination of orders 1 (blue), 2 (red), and 3 (green) in each detector column.</li>-->

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -33,6 +33,7 @@ from astropy.table import Table
 from exoctk.contam_visibility import field_simulator
 from exoctk.contam_visibility import resolve
 from exoctk.contam_visibility import new_vis_plot
+from exoctk.contam_visibility import contamination_figure
 from exoctk.contam_visibility.modes import CONTAM_VISIBILITY_MODES
 
 # Determine if tests are being run on Github Actions
@@ -129,6 +130,28 @@ def test_find_sources_identifies_high_proper_motion_target(monkeypatch):
     assert result['fluxscale'][0] == pytest.approx(1.)
     assert result['fluxscale'][1] < 1.e-4
     assert result['distance'][0] == pytest.approx(0.)
+
+
+def test_contamination_slider_uses_percent_and_common_display_cap():
+    """All supported modes share a 0--10% percent-based display."""
+
+    fractions = np.full((360, 3), 0.125)
+    plot = contamination_figure.contam_slider_plot(
+        [fractions], badPA_list=[0])
+    spectrum_plot, slider_row, pa_plot = plot.children
+    slider = slider_row.children[1]
+    line_renderer = spectrum_plot.renderers[0]
+    shading_renderer = pa_plot.renderers[0]
+    threshold_renderer = pa_plot.renderers[-1]
+
+    assert spectrum_plot.yaxis.axis_label == 'Contamination (%)'
+    assert pa_plot.yaxis.axis_label == 'Mean Contamination (%)'
+    assert spectrum_plot.y_range.end == 10
+    assert pa_plot.y_range.end == 10
+    assert slider.title == 'V3 Position Angle'
+    assert np.all(line_renderer.data_source.data['contam1'] == 12.5)
+    assert shading_renderer.data_source.data['top'][0] == 10
+    assert threshold_renderer.data_source.data['top'][0] == 10
 
 
 @pytest.mark.parametrize('aperture', [


### PR DESCRIPTION
Closes #713

- Display contamination in percent with a shared 0–10% visual range; values above 10% remain in the underlying data.
- Label the all-PA curve as mean contamination, matching the statistic plotted.
- Use the shared slider representation for supported SOSS and DHS web results.
- Clarify V3PA terminology, observability shading, threshold legends, and catalog/proper-motion caveats.

Tests: `pytest exoctk/tests/test_contam_visibility.py -q -k 'contamination_slider or contamination_supported'`