### PR TITLE
Cache source templates during contamination calculations

### DIFF
--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -6,7 +6,7 @@ A module to calculate the contamination and visibility of a target on a JWST det
 
 from copy import copy
 from datetime import datetime
-from functools import partial
+from functools import lru_cache, partial
 import glob
 import logging
 import os
@@ -1375,8 +1375,9 @@ def fetch_contam_results(exoplanet_name, db_filename):
     return target_trace, contamination, attrs
 
 
-def get_order0(aperture, teff, stype='STAR'):
-    """Get the order 0 image for the given aperture
+@lru_cache(maxsize=128)
+def _get_order0_cached(aperture, teff, stype):
+    """Load an immutable order-zero template for repeated rendering.
 
     Parameters
     ----------
@@ -1415,11 +1416,26 @@ def get_order0(aperture, teff, stype='STAR'):
             logging.info('Fetching {} galaxy trace from {}'.format(aperture, gal_path))
             trace = np.load(gal_path)
 
+    trace.setflags(write=False)
     return trace
 
 
-def get_trace(aperture, teff, stype, plot=False):
-    """Get the trace for the given aperture at the given temperature
+def get_order0(aperture, teff, stype='STAR'):
+    """Get an order-zero image, reusing the cached source template."""
+
+    cache_teff = int(round(float(teff))) if stype == 'STAR' else 0
+    return _get_order0_cached(aperture, cache_teff, stype)
+
+
+def _trace_cache_temperature(teff, stype):
+    """Return a stable cache key for a source template temperature."""
+
+    return int(round(float(teff))) if stype == 'STAR' else 0
+
+
+@lru_cache(maxsize=128)
+def _get_trace_cached(aperture, teff, stype):
+    """Load and prepare an immutable trace template for repeated rendering.
 
     Parameters
     ----------
@@ -1429,13 +1445,10 @@ def get_trace(aperture, teff, stype, plot=False):
         The temperature [K]
     stype: str
         The source type, ['STAR', 'GALAXY']
-    plot: bool
-        Plot the trace
-
     Returns
     -------
-    np.ndarray
-        The 2D trace
+    tuple of np.ndarray
+        Prepared trace templates. Callers must treat the arrays as read-only.
     """
     if 'DHS_F322W2' in aperture:
         aperpath = 'NRCA5_GRISM256_F322W2'
@@ -1502,10 +1515,24 @@ def get_trace(aperture, teff, stype, plot=False):
     else:
         traces = [fits.getdata(file)]
 
+    for trace in traces:
+        trace.setflags(write=False)
+
+    return tuple(traces)
+
+
+def get_trace(aperture, teff, stype, plot=False):
+    """Get prepared traces for a source, reusing cached detector templates."""
+
+    traces = list(_get_trace_cached(
+        aperture, _trace_cache_temperature(teff, stype), stype))
+
     if plot:
         f = figure(width=900, height=450)
         final = np.sum(traces, axis=0)
-        f.image([final], x=APERTURES[aperture]['subarr_x'][0], y=APERTURES[aperture]['subarr_y'][1], dw=final.shape[1], dh=final.shape[0])
+        f.image([final], x=APERTURES[aperture]['subarr_x'][0],
+                y=APERTURES[aperture]['subarr_y'][1],
+                dw=final.shape[1], dh=final.shape[0])
         show(f)
 
     return traces

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -131,6 +131,61 @@ def test_find_sources_identifies_high_proper_motion_target(monkeypatch):
     assert result['distance'][0] == pytest.approx(0.)
 
 
+def test_trace_templates_are_cached_across_position_angles(monkeypatch):
+    """Repeated source templates avoid repeated trace-file reads."""
+
+    calls = []
+    monkeypatch.setenv('EXOCTK_DATA', '/synthetic-data')
+    monkeypatch.setattr(
+        field_simulator.glob, 'glob',
+        lambda path: ['/synthetic-data/exoctk_contam/traces/'
+                      'NIS_SUBSTRIP256/trace_5000.fits'])
+
+    def synthetic_trace(filename, ext=0):
+        calls.append((filename, ext))
+        return np.full((2, 2), ext + 1., dtype=float)
+
+    monkeypatch.setattr(field_simulator.fits, 'getdata', synthetic_trace)
+    field_simulator._get_trace_cached.cache_clear()
+    try:
+        first = field_simulator.get_trace('NIS_SUBSTRIP256', 5000., 'STAR')
+        second = field_simulator.get_trace('NIS_SUBSTRIP256', 5000., 'STAR')
+    finally:
+        field_simulator._get_trace_cached.cache_clear()
+
+    assert len(calls) == 3
+    assert all(np.array_equal(before, after)
+               for before, after in zip(first, second))
+    assert all(not trace.flags.writeable for trace in first)
+
+
+def test_order_zero_templates_are_cached_across_position_angles(monkeypatch):
+    """Order-zero templates are also reused when rendering crowded fields."""
+
+    calls = []
+    monkeypatch.setenv('EXOCTK_DATA', '/synthetic-data')
+    monkeypatch.setattr(
+        field_simulator.glob, 'glob',
+        lambda path: ['/synthetic-data/exoctk_contam/order0/NIS_order0_5000.npy'])
+
+    def synthetic_order_zero(filename):
+        calls.append(filename)
+        return np.ones((2, 2), dtype=float)
+
+    monkeypatch.setattr(field_simulator.np, 'load', synthetic_order_zero)
+    field_simulator._get_order0_cached.cache_clear()
+    try:
+        first = field_simulator.get_order0('NIS_SUBSTRIP256', 5000., 'STAR')
+        second = field_simulator.get_order0('NIS_SUBSTRIP256', 5000., 'STAR')
+    finally:
+        field_simulator._get_order0_cached.cache_clear()
+
+    assert calls == [
+        '/synthetic-data/exoctk_contam/order0/NIS_order0_5000.npy']
+    assert np.array_equal(first, second)
+    assert not first.flags.writeable
+
+
 @pytest.mark.parametrize('aperture', [
     'NIS_SUBSTRIP96',
     'NIS_SUBSTRIP256',


### PR DESCRIPTION
Closes #714

- Cache immutable spectral-trace and order-zero templates by mode, source type, and temperature.
- Reuse cached templates across position angles while preserving per-angle placement and flux scaling.
- Eliminate repeated trace-file reads and template construction, reducing per-PA overhead—especially for crowded fields and DHS.
- Add regression coverage for repeated trace and order-zero template requests.

This change accelerates template preparation only; SIAF coordinate transforms, source placement, detector accumulation, and contamination reduction still run for every PA. End-to-end SOSS and DHS benchmarks remain a follow-up.

Tests: `pytest exoctk/tests/test_contam_visibility.py -q -k 'trace_templates_are_cached or order_zero_templates_are_cached'`