### PR TITLE
Fix SUBSTRIP96 contamination plots to omit uncalculated order 2

### DIFF
--- a/exoctk/contam_visibility/contamination_figure.py
+++ b/exoctk/contam_visibility/contamination_figure.py
@@ -173,6 +173,32 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
     return layout
 
 
+def soss_contamination_plot_layout(targframes, starcube, pctlines,
+                                   badPA_list, instrument, target_name):
+    """Return the legacy SOSS plot above the common slider plot.
+
+    The legacy image plot retains its wavelength-versus-position-angle view,
+    while the slider plot provides the extracted-contamination summary.  Both
+    are shown for SOSS so that established planning workflows remain available.
+    """
+    if not instrument.startswith('NIS'):
+        raise ValueError('Legacy contamination plots are available only for SOSS')
+    if len(targframes) < 2:
+        raise ValueError('SOSS legacy plots require target Orders 1 and 2')
+
+    n_pa, n_rows, n_columns = starcube.shape
+    legacy_cube = np.zeros((n_pa + 2, n_columns, n_rows))
+    legacy_cube[0] = targframes[0].T[::-1, ::-1]
+    legacy_cube[1] = targframes[1].T[::-1, ::-1]
+    legacy_cube[2:] = starcube.swapaxes(1, 2)[:, ::-1, ::-1]
+
+    legacy_plot = contam(
+        legacy_cube, instrument, targetName=target_name, badPAs=badPA_list)
+    slider_plot = contam_slider_plot(
+        pctlines, badPA_list, instrument=instrument)
+    return column(legacy_plot, slider_plot)
+
+
 def nirissContam(cube, paRange=[0, 360], lam_file=LAM_FILE):
     """ Generates the contamination figure that will be plotted on the website
     for NIRISS SOSS.

--- a/exoctk/contam_visibility/contamination_figure.py
+++ b/exoctk/contam_visibility/contamination_figure.py
@@ -37,6 +37,15 @@ lam0_nircam444w = 3.063
 lam1_nircam444w = 5.111
 
 
+def has_order2_contamination(instrument):
+    """Return whether the contamination calculation includes SOSS Order 2."""
+
+    # SUBSTRIP96 trace products contain only Order 1.  The legacy simulator
+    # reuses SUBSTRIP256 templates for source placement, so plotting its Order
+    # 2 panel would incorrectly imply a contamination calculation was done.
+    return instrument != 'NIS_SUBSTRIP96'
+
+
 def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1):
     """
     Make the contamination plot with a slider
@@ -442,7 +451,7 @@ def contam(cube, instrument, targetName='noName', paRange=[0, 360], badPAs=[]):
     # ~~~~~~ Order 2 ~~~~~~
 
     # Contam plot
-    if instrument.startswith('NIS'):
+    if instrument.startswith('NIS') and has_order2_contamination(instrument):
         xlim0 = lamO2.min()
         xlim1 = lamO2.max()
         ylim0 = PA.min() - 0.5 * dPA
@@ -496,7 +505,7 @@ def contam(cube, instrument, targetName='noName', paRange=[0, 360], badPAs=[]):
 
     # ~~~~~~ Plotting ~~~~~~
 
-    if instrument.startswith('NIS'):
+    if instrument.startswith('NIS') and has_order2_contamination(instrument):
         fig = gridplot(children=[[s2, s3], [s5, s6]])
     else:
         fig = gridplot(children=[[s2, s3]])

--- a/exoctk/contam_visibility/contamination_figure.py
+++ b/exoctk/contam_visibility/contamination_figure.py
@@ -46,7 +46,8 @@ def has_order2_contamination(instrument):
     return instrument != 'NIS_SUBSTRIP96'
 
 
-def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1):
+def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
+                       instrument=None):
     """
     Make the contamination plot with a slider
 
@@ -61,12 +62,21 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1):
     y_max: float
         The fractional contamination at the top of both displayed axes. Values
         above this limit remain in the data and are clipped only visually.
+    instrument: str, optional
+        Instrument aperture name. ``NIS_SUBSTRIP96`` displays only the
+        calculated SOSS Order 1 result.
 
     Returns
     -------
     bokeh.layouts.column
         The column of plots
     """
+    # SUBSTRIP96 trace products provide only SOSS Order 1. The simulator
+    # reuses SUBSTRIP256 templates for source placement, so its extra internal
+    # trace arrays must not be presented as calculated contamination results.
+    if instrument == 'NIS_SUBSTRIP96':
+        pctlines = pctlines[:1]
+
     # Quantities
     pa_list = np.arange(360)
     orders = np.arange(1, len(pctlines)+1)

--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -1328,7 +1328,8 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None, binComp=No
         # Make slider contam plot
         if slider:
             pctlines = fraction_contaminated(aperture, targframes, starcube)
-            contam_plot = cf.contam_slider_plot(pctlines, badPAs)
+            contam_plot = cf.contam_slider_plot(
+                pctlines, badPAs, instrument=aperture)
 
         # Make old contam plot
         else:

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -691,7 +691,8 @@ def contam_visibility():
             if fs.contamination_supported(form.inst.data):
                 pctlines = fs.fraction_contaminated(
                     form.inst.data, targframe, starcube)
-                contam_plot = cf.contam_slider_plot(pctlines, badPAs)
+                contam_plot = cf.contam_slider_plot(
+                    pctlines, badPAs, instrument=form.inst.data)
                 print("Made contamination slider plot")
             else:
                 # Retain the legacy image plot for any future mode that has not

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -691,9 +691,15 @@ def contam_visibility():
             if fs.contamination_supported(form.inst.data):
                 pctlines = fs.fraction_contaminated(
                     form.inst.data, targframe, starcube)
-                contam_plot = cf.contam_slider_plot(
-                    pctlines, badPAs, instrument=form.inst.data)
-                print("Made contamination slider plot")
+                if form.inst.data.startswith('NIS'):
+                    contam_plot = cf.soss_contamination_plot_layout(
+                        targframe, starcube, pctlines, badPAs,
+                        form.inst.data, form.targname.data)
+                    print("Made legacy and slider SOSS contamination plots")
+                else:
+                    contam_plot = cf.contam_slider_plot(
+                        pctlines, badPAs, instrument=form.inst.data)
+                    print("Made contamination slider plot")
             else:
                 # Retain the legacy image plot for any future mode that has not
                 # adopted the common contamination-slider representation.

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -278,6 +278,49 @@ def test_substrip96_slider_omits_uncalculated_orders():
                    for key in spectrum_plot.renderers[0].data_source.data)
 
 
+def test_soss_layout_places_legacy_plot_above_slider(monkeypatch):
+    """SOSS results retain the legacy view above the slider summary."""
+
+    legacy_plot = contamination_figure.Spacer(width=1, height=1)
+    slider_plot = contamination_figure.Spacer(width=2, height=2)
+    captured = {}
+
+    def fake_legacy(cube, instrument, targetName, badPAs):
+        captured['cube'] = cube
+        captured['instrument'] = instrument
+        captured['target_name'] = targetName
+        captured['bad_pas'] = badPAs
+        return legacy_plot
+
+    def fake_slider(pctlines, badPA_list, instrument):
+        captured['pctlines'] = pctlines
+        captured['slider_bad_pas'] = badPA_list
+        captured['slider_instrument'] = instrument
+        return slider_plot
+
+    monkeypatch.setattr(contamination_figure, 'contam', fake_legacy)
+    monkeypatch.setattr(contamination_figure, 'contam_slider_plot', fake_slider)
+    targframes = [np.arange(6).reshape(2, 3), np.arange(6, 12).reshape(2, 3)]
+    starcube = np.arange(24).reshape(4, 2, 3)
+    pctlines = [np.zeros((4, 3)), np.ones((4, 3))]
+
+    layout = contamination_figure.soss_contamination_plot_layout(
+        targframes, starcube, pctlines, [7], 'NIS_SUBSTRIP96', 'Target')
+
+    assert layout.children == [legacy_plot, slider_plot]
+    assert captured['instrument'] == 'NIS_SUBSTRIP96'
+    assert captured['slider_instrument'] == 'NIS_SUBSTRIP96'
+    assert captured['target_name'] == 'Target'
+    assert captured['bad_pas'] == [7]
+    assert captured['slider_bad_pas'] == [7]
+    np.testing.assert_array_equal(
+        captured['cube'][0], targframes[0].T[::-1, ::-1])
+    np.testing.assert_array_equal(
+        captured['cube'][1], targframes[1].T[::-1, ::-1])
+    np.testing.assert_array_equal(
+        captured['cube'][2:], starcube.swapaxes(1, 2)[:, ::-1, ::-1])
+
+
 def test_dhs_modes_available_in_web_form():
     """The web form exposes both supported NIRCam DHS filters."""
 

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -31,6 +31,7 @@ from pandas import DataFrame
 from astropy.table import Table
 
 from exoctk.contam_visibility import field_simulator
+from exoctk.contam_visibility import contamination_figure
 from exoctk.contam_visibility import resolve
 from exoctk.contam_visibility import new_vis_plot
 from exoctk.contam_visibility import contamination_figure
@@ -231,6 +232,32 @@ def test_contamination_not_supported(aperture):
     """Visibility-only modes must not run contamination calculations."""
 
     assert not field_simulator.contamination_supported(aperture)
+
+
+@pytest.mark.parametrize(('aperture', 'expected'), [
+    ('NIS_SUBSTRIP96', False),
+    ('NIS_SUBSTRIP256', True),
+    ('NRCA5_41STRIPE1_DHS_F322W2', True),
+])
+def test_order2_contamination_availability(aperture, expected):
+    """Only SUBSTRIP96 omits its uncalculated SOSS Order 2 output."""
+
+    assert contamination_figure.has_order2_contamination(aperture) is expected
+
+
+def test_substrip96_contamination_plot_omits_order2(monkeypatch):
+    """SUBSTRIP96 renders only its calculated Order 1 contamination panel."""
+
+    class Cube:
+        shape = (362, 2048, 96)
+
+    monkeypatch.setattr(
+        contamination_figure, 'nirissContam',
+        lambda cube, lam_file: (np.zeros((2048, 360)), np.zeros((2048, 360))))
+
+    plot = contamination_figure.contam(Cube(), 'NIS_SUBSTRIP96')
+
+    assert len(plot.children) == 2
 
 
 def test_dhs_modes_available_in_web_form():

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -260,6 +260,24 @@ def test_substrip96_contamination_plot_omits_order2(monkeypatch):
     assert len(plot.children) == 2
 
 
+def test_substrip96_slider_omits_uncalculated_orders():
+    """The web slider exposes only the calculated SUBSTRIP96 order."""
+
+    fractions = [np.full((360, 3), value) for value in (0.01, 0.02, 0.03)]
+    plot = contamination_figure.contam_slider_plot(
+        fractions, badPA_list=[], instrument='NIS_SUBSTRIP96')
+    spectrum_plot, _, pa_plot = plot.children
+
+    # One order produces one line and one filled area in the upper plot, and
+    # one mean curve plus one threshold region in the lower plot.
+    assert len(spectrum_plot.renderers) == 2
+    assert len(pa_plot.renderers) == 3
+    assert 'contam1' in spectrum_plot.renderers[0].data_source.data
+    assert 'contam2' not in spectrum_plot.renderers[0].data_source.data
+    assert not any(key.startswith('contam2_')
+                   for key in spectrum_plot.renderers[0].data_source.data)
+
+
 def test_dhs_modes_available_in_web_form():
     """The web form exposes both supported NIRCam DHS filters."""
 


### PR DESCRIPTION
## Summary

SUBSTRIP96 trace products calculate only SOSS Order 1. The simulator reuses SUBSTRIP256 templates internally for source placement, so displaying Orders 2 or 3 would incorrectly imply that their contamination was calculated.

The SOSS results page now retains both complementary planning views: the established wavelength-versus-position-angle image plot appears above the common extracted-contamination slider plot.

## Changes

- Restore the legacy SOSS contamination plot above the slider plot for NIRISS/SOSS modes.
- Add a helper identifying whether a mode includes a calculated SOSS Order 2 result.
- Omit the uncalculated Order 2 panel from the legacy SUBSTRIP96 plot layout.
- Pass the aperture name to the common contamination slider and display only Order 1 for SUBSTRIP96.
- Preserve the existing order display for SUBSTRIP256 and slider-only behavior for DHS modes.

## Testing

- Added regression coverage for order availability and the SUBSTRIP96 legacy plot layout.
- Added slider-plot coverage verifying that SUBSTRIP96 exposes only Order 1 data, its mean-contamination curve, and its threshold shading.
- Added layout coverage verifying that the legacy SOSS plot appears above the slider and that both receive the same contamination inputs.
- Focused plot tests: `6 passed`.
