### PR TITLE
Use Gaia DR3 DSC probabilities for contaminant classification

### DIFF
--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -555,8 +555,12 @@ def find_sources(ra=None, dec=None, target=None, width=7.5*u.arcmin, target_date
         # Join Gaia results with XMatch results based on source_id
         merged_results = join(stars, xmatch_result, keys='source_id', join_type='left')
 
-        # Extract SDSS DR16 source types from XMatch results
-        stars['type'] = ['STAR' if source_id not in xmatch_result['source_id'] else ('STAR' if sdss_type == '' else sdss_type) for source_id, sdss_type in zip(stars['source_id'], merged_results['spCl'])]
+        # Preserve only explicit SDSS rendering classes. Missing or blank spCl
+        # values must reach classify_source rather than masquerade as STAR.
+        stars['type'] = [
+            sdss_type if (not np.ma.is_masked(sdss_type)
+                          and sdss_type in ('STAR', 'GALAXY')) else ''
+            for sdss_type in merged_results['spCl']]
 
     except Exception as e:
         logging.info(f"Could not perform SDSS crossmatch: {e}")
@@ -774,6 +778,8 @@ def classify_source(row):
     str
         ``GALAXY`` for a confidently extended source; otherwise ``STAR``.
     """
+    # Endpoint-specific Gaia queries must retain and normalize these exact
+    # gaiadr3.gaia_source column names.
     probabilities = [
         _finite_float(row, 'classprob_dsc_combmod_star'),
         _finite_float(row, 'classprob_dsc_combmod_galaxy'),

--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -143,6 +143,9 @@ WEB_CONTAMINATION_APERTURES = frozenset({
     'NRCA5_41STRIPE1_DHS_F444W',
 })
 
+# Require a majority probability before rendering a source as extended.
+GAIA_DSC_GALAXY_THRESHOLD = 0.5
+
 
 def contamination_supported(aperture):
     """Return whether the contamination web interface supports an aperture."""
@@ -739,44 +742,80 @@ def add_source(startable, name, ra, dec, teff=None, fluxscale=None, delta_mag=No
     return startable
 
 
+def _finite_float(row, column_name):
+    """Return a finite scalar table value, or NaN when it is unusable."""
+
+    if (column_name not in row.colnames
+            or np.ma.is_masked(row[column_name])):
+        return np.nan
+
+    try:
+        value = float(row[column_name])
+    except (TypeError, ValueError):
+        return np.nan
+
+    return value if np.isfinite(value) else np.nan
+
+
 def classify_source(row):
     """
-    Classify a Gaia EDR3 source as STAR or GALAXY based on proxy criteria.
+    Classify a Gaia DR3 source as STAR or GALAXY for contamination rendering.
+
+    This binary rendering choice is not a complete astrophysical taxonomy:
+    quasars are point-like here and therefore render as ``STAR``.
 
     Parameters
     ----------
     row : astropy.table.Row
-        A single row from an Astropy Table with Gaia EDR3 columns.
+        A single row from an Astropy Table with Gaia DR3 columns.
 
     Returns
     -------
     str
-        'STAR' if the source appears to be stellar, 'GALAXY' otherwise.
+        ``GALAXY`` for a confidently extended source; otherwise ``STAR``.
     """
-    # Default is STAR
-    stype = 'STAR'
+    probabilities = [
+        _finite_float(row, 'classprob_dsc_combmod_star'),
+        _finite_float(row, 'classprob_dsc_combmod_galaxy'),
+        _finite_float(row, 'classprob_dsc_combmod_quasar'),
+    ]
+    if np.all(np.isfinite(probabilities)):
+        star_probability, galaxy_probability, quasar_probability = (
+            probabilities)
+        stype = 'GALAXY' if (
+            galaxy_probability >= GAIA_DSC_GALAXY_THRESHOLD
+            and galaxy_probability > star_probability
+            and galaxy_probability > quasar_probability
+        ) else 'STAR'
+        logging.info('Type=%s, Gaia DSC probabilities=%s', stype,
+                     probabilities)
+        return stype
 
-    # Check to see if GALAXY
-    if hasattr(row['parallax'], 'mask'):
+    upstream_type = row['type'] if 'type' in row.colnames else None
+    if (not np.ma.is_masked(upstream_type)
+            and upstream_type in ('STAR', 'GALAXY')):
+        return upstream_type
 
-        if hasattr(row['astrometric_excess_noise'], 'mask'):
-            if row['astrometric_excess_noise'] > 1.0:
-                stype = 'GALAXY'
+    parallax = _finite_float(row, 'parallax')
+    excess_noise = _finite_float(row, 'astrometric_excess_noise')
+    excess_factor = _finite_float(row, 'phot_bp_rp_excess_factor')
+    color = _finite_float(row, 'bp_rp')
 
-        if hasattr(row['phot_bp_rp_excess_factor'], 'mask') and hasattr(row['bp_rp'], 'mask'):
-            if row['phot_bp_rp_excess_factor'] > (1.0 + 0.015 * row['bp_rp']**2):
-                stype = 'GALAXY'
-
+    if np.isfinite(parallax):
+        stype = 'GALAXY' if parallax < 0.5 else 'STAR'
+    elif (np.isfinite(excess_noise) and excess_noise > 1.0) or (
+            np.isfinite(excess_factor) and np.isfinite(color)
+            and excess_factor > (1.0 + 0.015 * color**2)):
+        stype = 'GALAXY'
     else:
-        if row['parallax'] < 0.5:
-            stype = 'GALAXY'
+        stype = 'STAR'
 
-    msg = f"Type={stype}, parallax={row['parallax']}, excess noise="
-    msg += f"{row['astrometric_excess_noise']}, excess_factor="
-    msg += f"{row['phot_bp_rp_excess_factor']}"
+    msg = f"Type={stype}, parallax={parallax}, excess noise="
+    msg += f"{excess_noise}, excess_factor={excess_factor}"
     logging.info(msg)
 
     return stype
+
 
 def fraction_contaminated(aperture, targframes, starcube):
     """

--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -22,7 +22,6 @@ from urllib.parse import quote_plus
 
 import astropy.coordinates as crd
 from astropy.io import fits
-from astropy.table import join
 import astropy.units as u
 from astropy.stats import sigma_clip
 from astropy.table import Table
@@ -497,6 +496,36 @@ def _target_source_index(stars, target_coordinate, input_epoch=2000):
     return int(np.argmin(target_coordinate.separation(catalog_at_input_epoch)))
 
 
+def _normalize_sdss_type(value):
+    """Map an explicit SDSS class to a contamination rendering class."""
+
+    if np.ma.is_masked(value):
+        return None
+
+    value = str(value).strip().upper()
+    if value in ('STAR', 'QSO'):
+        return 'STAR'
+    if value == 'GALAXY':
+        return 'GALAXY'
+    return None
+
+
+def _sdss_type_lookup(xmatch_result):
+    """Return unanimous usable SDSS classes keyed by Gaia source ID."""
+
+    classifications = {}
+    for source_id, value in zip(
+            xmatch_result['source_id'], xmatch_result['spCl']):
+        normalized = _normalize_sdss_type(value)
+        if normalized is not None:
+            classifications.setdefault(source_id, set()).add(normalized)
+
+    return {
+        source_id: next(iter(values))
+        for source_id, values in classifications.items() if len(values) == 1
+    }
+
+
 def find_sources(ra=None, dec=None, target=None, width=7.5*u.arcmin, target_date=None, verbose=False, pm_corr=True, plot=False):
     """
     Find all the stars in the vicinity and estimate temperatures
@@ -552,15 +581,11 @@ def find_sources(ra=None, dec=None, target=None, width=7.5*u.arcmin, target_date
         # Perform XMatch between Gaia and SDSS DR16
         xmatch_result = XMatch.query(cat1=stars, cat2='vizier:V/154/sdss16', max_distance=2 * u.arcsec, colRA1='ra', colDec1='dec', colRA2='RA_ICRS', colDec2='DE_ICRS')
 
-        # Join Gaia results with XMatch results based on source_id
-        merged_results = join(stars, xmatch_result, keys='source_id', join_type='left')
-
-        # Preserve only explicit SDSS rendering classes. Missing or blank spCl
-        # values must reach classify_source rather than masquerade as STAR.
+        # XMatch can return multiple counterparts per Gaia source. Associate
+        # unanimous explicit classes by ID without reordering or expanding.
+        sdss_types = _sdss_type_lookup(xmatch_result)
         stars['type'] = [
-            sdss_type if (not np.ma.is_masked(sdss_type)
-                          and sdss_type in ('STAR', 'GALAXY')) else ''
-            for sdss_type in merged_results['spCl']]
+            sdss_types.get(source_id, '') for source_id in stars['source_id']]
 
     except Exception as e:
         logging.info(f"Could not perform SDSS crossmatch: {e}")
@@ -807,9 +832,9 @@ def classify_source(row):
     excess_factor = _finite_float(row, 'phot_bp_rp_excess_factor')
     color = _finite_float(row, 'bp_rp')
 
-    if np.isfinite(parallax):
-        stype = 'GALAXY' if parallax < 0.5 else 'STAR'
-    elif (np.isfinite(excess_noise) and excess_noise > 1.0) or (
+    # Retain the existing excess-noise and BP/RP-excess thresholds only as
+    # legacy extension proxies. Parallax alone is not galaxy evidence.
+    if (np.isfinite(excess_noise) and excess_noise > 1.0) or (
             np.isfinite(excess_factor) and np.isfinite(color)
             and excess_factor > (1.0 + 0.015 * color**2)):
         stype = 'GALAXY'

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -42,6 +42,32 @@ from exoctk.contam_visibility.modes import CONTAM_VISIBILITY_MODES
 ON_GITHUB_ACTIONS = '/home/runner' in os.path.expanduser('~') or '/Users/runner' in os.path.expanduser('~')
 
 
+def classification_row(mask_dsc=False, mask_columns=(), **values):
+    """Build one synthetic Gaia row for source-classification tests."""
+
+    defaults = {
+        'classprob_dsc_combmod_star': np.nan,
+        'classprob_dsc_combmod_galaxy': np.nan,
+        'classprob_dsc_combmod_quasar': np.nan,
+        'parallax': 1.,
+        'astrometric_excess_noise': 0.,
+        'phot_bp_rp_excess_factor': 1.,
+        'bp_rp': 1.,
+    }
+    defaults.update(values)
+    table = Table({name: [value] for name, value in defaults.items()},
+                  masked=True)
+    if mask_dsc:
+        for name in (
+                'classprob_dsc_combmod_star',
+                'classprob_dsc_combmod_galaxy',
+                'classprob_dsc_combmod_quasar'):
+            table[name].mask[0] = True
+    for name in mask_columns:
+        table[name].mask[0] = True
+    return table[0]
+
+
 def test_new_vis_plot():
     """Tests the `new_vis_plot.py` module"""
     ra, dec = '24.3544618', '-45.6777937' # WASP-18
@@ -94,6 +120,73 @@ def test_resolve_target():
 
     assert ra == 24.3544618
     assert dec == -45.6777937
+
+
+@pytest.mark.parametrize(('probabilities', 'expected'), [
+    ((0.9, 0.05, 0.05), 'STAR'),
+    ((0.05, 0.9, 0.05), 'GALAXY'),
+    ((0.05, 0.05, 0.9), 'STAR'),
+    ((0.4, 0.4, 0.2), 'STAR'),
+])
+def test_classify_source_uses_gaia_dsc(probabilities, expected):
+    """Gaia DSC drives the binary contamination-rendering classification."""
+
+    star, galaxy, quasar = probabilities
+    row = classification_row(
+        classprob_dsc_combmod_star=star,
+        classprob_dsc_combmod_galaxy=galaxy,
+        classprob_dsc_combmod_quasar=quasar,
+        parallax=0.)
+
+    assert field_simulator.classify_source(row) == expected
+
+
+def test_classify_source_masked_dsc_uses_fallback():
+    """Masked DSC values use the finite astrometric proxy without crashing."""
+
+    row = classification_row(mask_dsc=True, parallax=0.1)
+
+    assert field_simulator.classify_source(row) == 'GALAXY'
+
+
+def test_classify_source_nan_and_masked_values_match():
+    """NaN and masked DSC and parallax values have the same safe default."""
+
+    nan_row = classification_row(parallax=np.nan)
+    masked_row = classification_row(
+        mask_dsc=True, mask_columns=('parallax',))
+
+    assert field_simulator.classify_source(nan_row) == 'STAR'
+    assert field_simulator.classify_source(masked_row) == 'STAR'
+
+
+def test_classify_source_missing_parallax_is_not_a_galaxy():
+    """Missing parallax alone must not suppress a dispersed contaminant."""
+
+    row = classification_row(mask_dsc=True, parallax=np.nan)
+
+    assert field_simulator.classify_source(row) == 'STAR'
+
+
+def test_classify_source_regression_gaia_3910744542517589888():
+    """The independently confirmed point source remains a STAR."""
+
+    row = classification_row(
+        classprob_dsc_combmod_star=0.997072,
+        classprob_dsc_combmod_galaxy=0.000248,
+        classprob_dsc_combmod_quasar=0.001099,
+        parallax=np.nan)
+
+    assert field_simulator.classify_source(row) == 'STAR'
+
+
+@pytest.mark.parametrize('source_type', ['STAR', 'GALAXY'])
+def test_classify_source_preserves_valid_upstream_type(source_type):
+    """A valid upstream type survives when Gaia DSC is unavailable."""
+
+    row = classification_row(type=source_type, parallax=10.)
+
+    assert field_simulator.classify_source(row) == source_type
 
 
 def test_find_sources_identifies_high_proper_motion_target(monkeypatch):

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -126,6 +126,8 @@ def test_resolve_target():
     ((0.9, 0.05, 0.05), 'STAR'),
     ((0.05, 0.9, 0.05), 'GALAXY'),
     ((0.05, 0.05, 0.9), 'STAR'),
+    ((0.3, 0.5, 0.2), 'GALAXY'),
+    ((0.5, 0.5, 0.), 'STAR'),
     ((0.4, 0.4, 0.2), 'STAR'),
 ])
 def test_classify_source_uses_gaia_dsc(probabilities, expected):
@@ -147,6 +149,19 @@ def test_classify_source_masked_dsc_uses_fallback():
     row = classification_row(mask_dsc=True, parallax=0.1)
 
     assert field_simulator.classify_source(row) == 'GALAXY'
+
+
+def test_classify_source_one_masked_dsc_probability_defaults_to_star():
+    """One missing DSC probability makes the full DSC result unusable."""
+
+    row = classification_row(
+        mask_columns=('classprob_dsc_combmod_quasar',),
+        classprob_dsc_combmod_star=0.1,
+        classprob_dsc_combmod_galaxy=0.9,
+        classprob_dsc_combmod_quasar=0.,
+        parallax=np.nan)
+
+    assert field_simulator.classify_source(row) == 'STAR'
 
 
 def test_classify_source_nan_and_masked_values_match():
@@ -187,6 +202,47 @@ def test_classify_source_preserves_valid_upstream_type(source_type):
     row = classification_row(type=source_type, parallax=10.)
 
     assert field_simulator.classify_source(row) == source_type
+
+
+@pytest.mark.parametrize(('sdss_type', 'expected'), [
+    ('STAR', 'STAR'),
+    ('', 'GALAXY'),
+    (None, 'GALAXY'),
+])
+def test_find_sources_preserves_only_explicit_sdss_type(
+        monkeypatch, sdss_type, expected):
+    """Blank or missing SDSS spCl must reach the fallback classifier."""
+
+    stars = Table({
+        'source_id': [1],
+        'ra': [10.],
+        'dec': [20.],
+        'pmra': [0.],
+        'pmdec': [0.],
+        'ref_epoch': [2016.],
+        'phot_g_mean_flux': [100.],
+        'bp_rp': [1.],
+        'parallax': [0.1],
+        'astrometric_excess_noise': [0.],
+        'phot_bp_rp_excess_factor': [1.],
+        'classprob_dsc_combmod_star': [np.nan],
+        'classprob_dsc_combmod_galaxy': [np.nan],
+        'classprob_dsc_combmod_quasar': [np.nan],
+    })
+    if sdss_type is None:
+        xmatch = Table(names=('source_id', 'spCl'), dtype=('i8', 'U10'))
+    else:
+        xmatch = Table({'source_id': [1], 'spCl': [sdss_type]})
+    monkeypatch.setattr(
+        field_simulator.GAIA_TAP, 'query_region',
+        lambda *args, **kwargs: stars.copy())
+    monkeypatch.setattr(
+        field_simulator.XMatch, 'query',
+        lambda *args, **kwargs: xmatch)
+
+    result = field_simulator.find_sources(10., 20., pm_corr=False)
+
+    assert result['type'][0] == expected
 
 
 def test_find_sources_identifies_high_proper_motion_target(monkeypatch):

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -68,6 +68,28 @@ def classification_row(mask_dsc=False, mask_columns=(), **values):
     return table[0]
 
 
+def gaia_source_table(source_ids, excess_noise=0.):
+    """Build a minimal Gaia result table for find_sources tests."""
+
+    count = len(source_ids)
+    return Table({
+        'source_id': source_ids,
+        'ra': 10. + np.arange(count) * 0.001,
+        'dec': np.full(count, 20.),
+        'pmra': np.zeros(count),
+        'pmdec': np.zeros(count),
+        'ref_epoch': np.full(count, 2016.),
+        'phot_g_mean_flux': np.full(count, 100.),
+        'bp_rp': np.ones(count),
+        'parallax': np.full(count, 0.1),
+        'astrometric_excess_noise': np.full(count, excess_noise),
+        'phot_bp_rp_excess_factor': np.ones(count),
+        'classprob_dsc_combmod_star': np.full(count, np.nan),
+        'classprob_dsc_combmod_galaxy': np.full(count, np.nan),
+        'classprob_dsc_combmod_quasar': np.full(count, np.nan),
+    })
+
+
 def test_new_vis_plot():
     """Tests the `new_vis_plot.py` module"""
     ra, dec = '24.3544618', '-45.6777937' # WASP-18
@@ -144,9 +166,20 @@ def test_classify_source_uses_gaia_dsc(probabilities, expected):
 
 
 def test_classify_source_masked_dsc_uses_fallback():
-    """Masked DSC values use the finite astrometric proxy without crashing."""
+    """Strong excess noise remains a legacy extension proxy."""
 
-    row = classification_row(mask_dsc=True, parallax=0.1)
+    row = classification_row(
+        mask_dsc=True, parallax=0.1, astrometric_excess_noise=2.)
+
+    assert field_simulator.classify_source(row) == 'GALAXY'
+
+
+def test_classify_source_bp_rp_excess_uses_fallback_proxy():
+    """Strong BP/RP excess remains a legacy extension proxy."""
+
+    row = classification_row(
+        mask_dsc=True, parallax=np.nan, bp_rp=1.,
+        phot_bp_rp_excess_factor=2.)
 
     assert field_simulator.classify_source(row) == 'GALAXY'
 
@@ -183,6 +216,14 @@ def test_classify_source_missing_parallax_is_not_a_galaxy():
     assert field_simulator.classify_source(row) == 'STAR'
 
 
+def test_classify_source_low_parallax_is_not_a_galaxy():
+    """Low finite parallax alone must not imply an extended source."""
+
+    row = classification_row(mask_dsc=True, parallax=0.1)
+
+    assert field_simulator.classify_source(row) == 'STAR'
+
+
 def test_classify_source_regression_gaia_3910744542517589888():
     """The independently confirmed point source remains a STAR."""
 
@@ -206,31 +247,26 @@ def test_classify_source_preserves_valid_upstream_type(source_type):
 
 @pytest.mark.parametrize(('sdss_type', 'expected'), [
     ('STAR', 'STAR'),
-    ('', 'GALAXY'),
-    (None, 'GALAXY'),
+    ('GALAXY', 'GALAXY'),
+    ('QSO', 'STAR'),
+    (' qso ', 'STAR'),
+    ('star', 'STAR'),
+    ('Galaxy', 'GALAXY'),
+    ('', 'STAR'),
+    ('<masked>', 'STAR'),
+    (None, 'STAR'),
+    ('UNKNOWN', 'STAR'),
 ])
-def test_find_sources_preserves_only_explicit_sdss_type(
+def test_find_sources_normalizes_explicit_sdss_type(
         monkeypatch, sdss_type, expected):
-    """Blank or missing SDSS spCl must reach the fallback classifier."""
+    """Production flow normalizes usable SDSS classes by rendering type."""
 
-    stars = Table({
-        'source_id': [1],
-        'ra': [10.],
-        'dec': [20.],
-        'pmra': [0.],
-        'pmdec': [0.],
-        'ref_epoch': [2016.],
-        'phot_g_mean_flux': [100.],
-        'bp_rp': [1.],
-        'parallax': [0.1],
-        'astrometric_excess_noise': [0.],
-        'phot_bp_rp_excess_factor': [1.],
-        'classprob_dsc_combmod_star': [np.nan],
-        'classprob_dsc_combmod_galaxy': [np.nan],
-        'classprob_dsc_combmod_quasar': [np.nan],
-    })
+    stars = gaia_source_table([1])
     if sdss_type is None:
         xmatch = Table(names=('source_id', 'spCl'), dtype=('i8', 'U10'))
+    elif sdss_type == '<masked>':
+        xmatch = Table({'source_id': [1], 'spCl': ['STAR']}, masked=True)
+        xmatch['spCl'].mask[0] = True
     else:
         xmatch = Table({'source_id': [1], 'spCl': [sdss_type]})
     monkeypatch.setattr(
@@ -243,6 +279,54 @@ def test_find_sources_preserves_only_explicit_sdss_type(
     result = field_simulator.find_sources(10., 20., pm_corr=False)
 
     assert result['type'][0] == expected
+
+
+def test_find_sources_associates_sdss_types_by_source_id(monkeypatch):
+    """SDSS types remain attached when Gaia IDs are out of key order."""
+
+    stars = gaia_source_table([30, 10, 20])
+    xmatch = Table({
+        'source_id': [20, 10],
+        'spCl': ['GALAXY', 'STAR'],
+    })
+    monkeypatch.setattr(
+        field_simulator.GAIA_TAP, 'query_region',
+        lambda *args, **kwargs: stars.copy())
+    monkeypatch.setattr(
+        field_simulator.XMatch, 'query',
+        lambda *args, **kwargs: xmatch)
+
+    result = field_simulator.find_sources(10., 20., pm_corr=False)
+
+    assert list(result['source_id']) == [30, 10, 20]
+    assert list(result['type']) == ['STAR', 'STAR', 'GALAXY']
+    assert len(result) == len(stars)
+
+
+@pytest.mark.parametrize(('sdss_types', 'expected'), [
+    (['STAR', ' qso '], 'STAR'),
+    (['STAR', 'GALAXY'], 'GALAXY'),
+])
+def test_find_sources_handles_duplicate_sdss_matches(
+        monkeypatch, sdss_types, expected):
+    """Duplicate matches are preserved only when usable classes agree."""
+
+    stars = gaia_source_table([1], excess_noise=2.)
+    xmatch = Table({
+        'source_id': [1] * len(sdss_types),
+        'spCl': sdss_types,
+    })
+    monkeypatch.setattr(
+        field_simulator.GAIA_TAP, 'query_region',
+        lambda *args, **kwargs: stars.copy())
+    monkeypatch.setattr(
+        field_simulator.XMatch, 'query',
+        lambda *args, **kwargs: xmatch)
+
+    result = field_simulator.find_sources(10., 20., pm_corr=False)
+
+    assert result['type'][0] == expected
+    assert len(result) == 1
 
 
 def test_find_sources_identifies_high_proper_motion_target(monkeypatch):


### PR DESCRIPTION
## Summary

Use Gaia DR3 DSC probabilities as the primary basis for deciding whether contamination-tool sources are rendered as point-like `STAR` sources with dispersed orders or with the extended-source `GALAXY` treatment.

When Gaia DSC is unavailable, explicit SDSS classifications are associated with the correct Gaia sources by `source_id`, normalized to ExoCTK's binary rendering classes, and used before the legacy fallback heuristics.

## Scientific motivation

The previous fallback used fragile masked-scalar checks that could bypass intended quality criteria. Historical behavior also treated low or missing parallax as evidence for `GALAXY`, which could suppress real dispersed contaminants.

Gaia source `3910744542517589888` has `P(star) = 0.997072`, consistent with independent SDSS stellar morphology and point-source-like WISE measurements, so it should remain classified as `STAR`.

The `STAR` and `GALAXY` labels used here describe contamination-rendering behavior rather than a complete astrophysical taxonomy.

## Classification behavior

When all three Gaia DSC probabilities are finite, classify a source as `GALAXY` only when `P(galaxy) >= 0.5` and is strictly greater than both `P(star)` and `P(quasar)`. Otherwise classify it as `STAR`, including ties, ambiguous cases, and quasar-like point sources.

When DSC is incomplete or unusable, explicit SDSS values are normalized case-insensitively after trimming whitespace:

- `STAR` and `QSO` map to point-like `STAR`
- `GALAXY` maps to `GALAXY`
- Blank, masked, missing, and unknown values provide no upstream classification

SDSS results are grouped by Gaia `source_id` without joining or reordering the Gaia table. Duplicate usable classifications are retained only when their normalized rendering classes agree. Conflicting classifications are treated as unavailable and proceed to fallback classification.

The fallback no longer treats low, missing, masked, or non-finite parallax as galaxy evidence. It retains the existing `astrometric_excess_noise > 1.0` and BP/RP-excess relation as documented legacy extension heuristics. Otherwise, uncertain sources default conservatively to `STAR`.

## Tests

Added network-independent Astropy coverage for:

- Gaia DSC classes and decision boundaries
- Masked and non-finite values
- Low and missing parallax
- Both retained extension heuristics
- SDSS normalization, including QSO, case, and whitespace
- Blank, masked, missing, and unknown SDSS values
- Source-ID-safe association with deliberately unordered Gaia IDs
- Unanimous and conflicting duplicate matches
- Gaia source `3910744542517589888`

Local validation passes the complete contamination test module: `55 passed`.

## Scope exclusions

This PR does not change TAP endpoints or query architecture, cache behavior, source-count or flux limits, order-0 calibration, or the broader contamination-simulator structure.

It includes no investigation catalogs, reports, generated data, or large fixtures.

## Compatibility considerations

Public function signatures and output structures are unchanged.

The implementation expects the internal Gaia DSC columns:

- `classprob_dsc_combmod_star`
- `classprob_dsc_combmod_galaxy`
- `classprob_dsc_combmod_quasar`

Future endpoint-specific TAP adapters must request equivalent classification data where available and normalize their native schemas to these internal column names.