### PR TITLE
Add endpoint-aware Gaia TAP failover

### DIFF
--- a/docker/exoctk/exoctk_test_script.sh
+++ b/docker/exoctk/exoctk_test_script.sh
@@ -45,10 +45,19 @@
 #   them for accuracy, but for the moment this is testing whether you can *do* things,
 #   with the rest of the test suite making sure the module results are accurate.
 
+log()
+{
+    printf '[%s] [website-test] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+log "Waiting for the ExoCTK server volume"
 until cd /exoctk/exoctk/
 do
-    echo "Waiting for server volume..."
+    log "Server volume is not ready; checking again in 5 seconds"
+    sleep 5
 done
+log "Server volume is ready; starting Selenium tests with unbuffered output"
 
 # Run the Selenium script
-python /exoctk/test_exoctk_page.py
+export PYTHONUNBUFFERED=1
+exec python -u /exoctk/test_exoctk_page.py

--- a/docker/exoctk/test_exoctk_page.py
+++ b/docker/exoctk/test_exoctk_page.py
@@ -56,8 +56,12 @@ The dictionary has the following form:
         This is a list of dictionaries of steps to run after the form results have loaded.
         The dictionary format is described in the `run_action()` documentation.
 """
+from datetime import datetime, timezone
 from pathlib import Path
+import time
+
 from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options
@@ -67,16 +71,27 @@ from selenium.webdriver.support.wait import WebDriverWait
 from tabulate import tabulate
 
 
+PROGRESS_INTERVAL = 30
+
+
+def log(message=""):
+    """Print an immediately visible, timestamped website-test message."""
+
+    timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    print(f'[{timestamp}] [website-test] {message}', flush=True)
+
+
 def print_page_title(url, options, service):
     with webdriver.Firefox(options=options, service=service) as driver:
+        log(f'Loading website root: {url}')
         driver.get(url)
-        print(f"Title: {driver.title}")
+        log(f"Title: {driver.title}")
         h1_elements = driver.find_elements(By.TAG_NAME, "h1")
         if len(h1_elements) > 0:
-            print(f"Top Title: {h1_elements[0].text}")
+            log(f"Top Title: {h1_elements[0].text}")
 
 def print_table(table_array):
-    print(f"\n{tabulate(table_array, headers='firstrow', tablefmt='simple')}")
+    log(f"\n{tabulate(table_array, headers='firstrow', tablefmt='simple')}")
 
 def print_tables(driver, find_by, id):
     tables = driver.find_elements(find_by, id)
@@ -148,30 +163,30 @@ def run_action(driver, action, wait_time=1.0, timeout=10.0):
 
     if action["type"] == "print_title":
         # Print the page title
-        print(driver.title)
+        log(driver.title)
     elif action["type"] == "print_head":
         # Print the text in the first <h1> element in the page
         h1_elements = driver.find_elements(By.TAG_NAME, "h1")
         if len(h1_elements) > 0:
-            print(h1_elements[0].text)
+            log(h1_elements[0].text)
     elif action['type'] == "print_table":
         print_tables(driver, action['find_by'], action['id'])
     elif action['type'] == "print_value":
         element = driver.find_element(action['find_by'], action['id'])
-        print(f"Element {action['id']} has value {element.get_attribute('value')}")
+        log(f"Element {action['id']} has value {element.get_attribute('value')}")
     elif action["type"] == "set_text":
         # Set a field whose value can be set with `send_keys()`
         element = driver.find_element(action["find_by"], action["find_value"])
-        print(f"Set {action['find_value']} from {element.get_attribute('value')} to {action['value']}")
+        log(f"Set {action['find_value']} from {element.get_attribute('value')} to {action['value']}")
         element.clear()
         element.send_keys(action["value"])
-        print(f"Element {action['find_value']} value is {element.get_attribute('value')}")
+        log(f"Element {action['find_value']} value is {element.get_attribute('value')}")
     elif action["type"] == "resolve_target":
         # Set the target of observation to the provided value, trigger it.
         # Print out the provided check element before and after to make sure it took.
         check_element = driver.find_element(By.ID, action["target_check"])
         check_value = check_element.get_attribute('value')
-        print(f"Element {action['target_check']} before target resolution: {check_value}")
+        log(f"Element {action['target_check']} before target resolution: {check_value}")
         target = driver.find_element(By.ID, action["target_id"])
         target.send_keys(action['target'])
         resolve = wait.until(EC.element_to_be_clickable((By.ID, "resolve_submit")))
@@ -179,14 +194,14 @@ def run_action(driver, action, wait_time=1.0, timeout=10.0):
         resolve.click()
         check_element = driver.find_element(By.ID, action["target_check"])
         check_value = check_element.get_attribute('value')
-        print(f"Element {action['target_check']} after target resolution: {check_value}")
+        log(f"Element {action['target_check']} after target resolution: {check_value}")
     elif action['type'] == "download":
         element = driver.find_element(action['find_by'], action['id'])
         element.click()
         driver.implicitly_wait(wait_time)
         file_location = Path(f"/root/Downloads/{action['file']}")
         if file_location.is_file():
-            print(f"Downloaded {action['file']}")
+            log(f"Downloaded {action['file']}")
             file_location.unlink()
         else:
             raise FileNotFoundError(f"Downloaded file {action['file']} not found")
@@ -195,20 +210,48 @@ def do_submit(driver, params, calculation_timeout=2700):
     """
     Finds the submit button, waits for it to be pushable, and pushes it.
     """
-    submit_element = WebDriverWait(driver, "10").until(
+    test_name = params['name']
+    log(f'[{test_name}] Waiting for submit button #{params["submit_id"]}')
+    submit_element = WebDriverWait(driver, 10).until(
         EC.element_to_be_clickable((By.ID, params["submit_id"]))
     )
-    WebDriverWait(driver, "10").until(
+    WebDriverWait(driver, 10).until(
         EC.invisibility_of_element_located((By.ID, "MathJax_Message"))
     )
     submit_element.click()
+    started = time.monotonic()
+    log(f'[{test_name}] Submitted; current URL: {driver.current_url}')
     if params['submit_done_type'] == "simple_wait":
         driver.implicitly_wait(params['submit_done_value'])
+        log(f'[{test_name}] Configured Selenium implicit wait of '
+            f'{params["submit_done_value"]:.1f} seconds for result checks')
     else:
-        submit_done = WebDriverWait(driver, calculation_timeout).until(
-            EC.presence_of_element_located((params["submit_done_type"],
-            params['submit_done_id']))
-        )
+        locator = (params["submit_done_type"], params['submit_done_id'])
+        log(f'[{test_name}] Waiting up to {calculation_timeout} seconds for '
+            f'result element {locator!r}')
+        next_report = PROGRESS_INTERVAL
+        while True:
+            if driver.find_elements(*locator):
+                elapsed = time.monotonic() - started
+                log(f'[{test_name}] Found result element after '
+                    f'{elapsed:.1f} seconds')
+                return
+
+            elapsed = time.monotonic() - started
+            if elapsed >= calculation_timeout:
+                log(f'[{test_name}] Timed out after {elapsed:.1f} seconds; '
+                    f'URL={driver.current_url!r}, title={driver.title!r}')
+                raise TimeoutException(
+                    f'{test_name} did not produce {locator!r} within '
+                    f'{calculation_timeout} seconds; URL={driver.current_url!r}, '
+                    f'title={driver.title!r}')
+
+            if elapsed >= next_report:
+                log(f'[{test_name}] Still waiting for {locator!r}: '
+                    f'{elapsed:.0f}/{calculation_timeout} seconds elapsed; '
+                    f'URL={driver.current_url}')
+                next_report += PROGRESS_INTERVAL
+            time.sleep(1)
 
 def do_form(options, service, params):
     """
@@ -216,30 +259,47 @@ def do_form(options, service, params):
     Submits the form.
     Runs all the elements in the post_steps in order.
     """
-    run_str = f"Running Test {params['name']}"
-    print()
-    print(run_str)
-    print("-" * len(run_str))
+    test_name = params['name']
+    test_started = time.monotonic()
+    run_str = f"Running Test {test_name}"
+    log()
+    log(run_str)
+    log("-" * len(run_str))
     with webdriver.Firefox(options=options, service=service) as driver:
-        # Load groups-integrations page
-        driver.get(params['url'] + params['extension'])
+        test_url = params['url'] + params['extension']
+        log(f'[{test_name}] Loading {test_url}')
+        driver.get(test_url)
+        log(f'[{test_name}] Page loaded: title={driver.title!r}, '
+            f'URL={driver.current_url}')
 
-        for action in params['pre_steps']:
+        for index, action in enumerate(params['pre_steps'], start=1):
+            log(f'[{test_name}] Starting pre-step {index}/'
+                f'{len(params["pre_steps"])}: {action["type"]}')
             run_action(driver, action)
+            log(f'[{test_name}] Finished pre-step {index}/'
+                f'{len(params["pre_steps"])}: {action["type"]}')
 
         # Submit the form
-        print("Starting Calculation")
+        log(f'[{test_name}] Starting calculation')
         do_submit(driver, params)
-        print("Finished Calculation")
+        log(f'[{test_name}] Finished calculation')
 
         # Do all the post-calculation steps
-        for action in params["post_steps"]:
+        for index, action in enumerate(params["post_steps"], start=1):
+            log(f'[{test_name}] Starting post-step {index}/'
+                f'{len(params["post_steps"])}: {action["type"]}')
             run_action(driver, action)
-    print("-" * len(run_str))
-    print()
+            log(f'[{test_name}] Finished post-step {index}/'
+                f'{len(params["post_steps"])}: {action["type"]}')
+    elapsed = time.monotonic() - test_started
+    log(f'[{test_name}] PASSED in {elapsed:.1f} seconds')
+    log("-" * len(run_str))
+    log()
 
 
 if __name__ == "__main__":
+    suite_started = time.monotonic()
+    log('Starting ExoCTK website test suite')
     # Let's make functions
     options = Options()
     options.binary_location = r'/usr/bin/firefox-esr'
@@ -248,7 +308,7 @@ if __name__ == "__main__":
 
     url = "http://localhost:5000"
     print_page_title(url, options, service)
-    print()
+    log()
 
     group_integration_params = {
         'name': 'Groups/Integrations',
@@ -531,3 +591,5 @@ if __name__ == "__main__":
         ]
     }
     do_form(options, service, contam_overlap_full_params)
+    log(f'Completed ExoCTK website test suite in '
+        f'{time.monotonic() - suite_started:.1f} seconds')

--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -16,8 +16,6 @@ import re
 import sys
 import time
 import logging
-import io
-import requests
 from urllib.parse import quote_plus
 
 import astropy.coordinates as crd
@@ -46,6 +44,7 @@ from ..pkgdata import resource_filename
 from .new_vis_plot import build_visibility_plot, get_exoplanet_positions
 from .precompute import save_exoplanet_data
 from . import contamination_figure as cf
+from .gaia_tap import GaiaFailoverTAP
 
 import warnings
 warnings.filterwarnings("ignore", message="Mean of empty slice")
@@ -173,169 +172,6 @@ DHS_STRIPES = {'NRCA5_41STRIPE1_DHS_F322W2': {'DHS5': {'x0': 2196, 'x1': 3324, '
 
 # Gaia color-Teff relation
 GAIA_TEFFS = np.asarray(np.genfromtxt(resource_filename('exoctk', 'data/contam_visibility/predicted_gaia_colour.txt'), unpack=True))
-
-class GaiaFailoverTAP:
-    def __init__(
-        self,
-        timeout=30,
-        poll_interval=1.0,
-        max_polls=120,
-        max_retries=3,
-        retry_delay=5,
-    ):
-        self.endpoints = [
-            "https://gea.esac.esa.int/tap-server/tap",
-            "https://datalab.noirlab.edu/tap",
-            "https://tapvizier.cds.unistra.fr/TAPVizieR/tap"
-        ]
-
-        self.timeout = timeout
-        self.poll_interval = poll_interval
-        self.max_polls = max_polls
-
-        # NEW
-        self.max_retries = max_retries
-        self.retry_delay = retry_delay
-
-        self.last_endpoint = None
-
-    def query_region(self, coordinate, width, height=None):
-        """
-        Drop-in replacement for Gaia.query_object_async(...)
-
-        Returns
-        -------
-        astropy.table.Table
-        """
-        height = width if height is None else height
-
-        ra = float(coordinate.ra.deg)
-        dec = float(coordinate.dec.deg)
-
-        width_deg = float(width.to(u.deg).value)
-        height_deg = float(height.to(u.deg).value)
-
-        # Query enclosing circle
-        radius_deg = 0.5 * np.sqrt(width_deg**2 + height_deg**2)
-
-        if not np.isfinite(radius_deg) or radius_deg <= 0:
-            raise ValueError(f"Invalid radius: {radius_deg}")
-
-        adql = f"""
-        SELECT *,
-            DISTANCE(
-                POINT('ICRS', ra, dec),
-                POINT('ICRS', {ra}, {dec})
-            ) AS dist
-        FROM gaiadr3.gaia_source
-        WHERE 1=CONTAINS(
-            POINT('ICRS', ra, dec),
-            CIRCLE('ICRS', {ra}, {dec}, {radius_deg})
-        )
-        ORDER BY dist
-        """
-
-        all_errors = []
-
-        # GLOBAL RETRY LOOP
-        for retry in range(self.max_retries):
-
-            logging.info(
-                f"[Gaia TAP] Global retry "
-                f"{retry + 1}/{self.max_retries}"
-            )
-
-            # ENDPOINT FAILOVER LOOP
-            for endpoint in self.endpoints:
-
-                try:
-                    stars = self._run_query(endpoint, adql)
-                    self.last_endpoint = endpoint
-                    logging.info(
-                        f"[Gaia TAP] SUCCESS "
-                        f"endpoint={endpoint} "
-                        f"rows={len(stars)}"
-                    )
-
-                    return stars
-
-                except Exception as e:
-                    err_msg = (
-                        f"[Gaia failover] "
-                        f"retry={retry + 1} "
-                        f"endpoint={endpoint} "
-                        f"error={e}"
-                    )
-
-                    logging.warning(err_msg)
-                    all_errors.append(err_msg)
-
-            # Sleep before next global retry
-            if retry < self.max_retries - 1:
-                delay = self.retry_delay * (2**retry)
-                logging.info(f"[Gaia TAP] Sleeping {delay}s before retry")
-                time.sleep(delay)
-
-        # TOTAL FAILURE
-        raise RuntimeError(
-            "All Gaia TAP endpoints failed after "
-            f"{self.max_retries} retries.\n\n"
-            + "\n".join(all_errors)
-        )
-
-    def _run_query(self, endpoint, adql):
-        job_url = self._submit_async_job(endpoint, adql)
-        self._poll_job(job_url)
-        return self._fetch_result(job_url)
-
-    def _submit_async_job(self, endpoint, adql):
-        url = f"{endpoint}/async"
-        r = requests.post(url, data={"REQUEST": "doQuery", "LANG": "ADQL", "FORMAT": "csv", "QUERY": adql, "PHASE": "RUN"}, timeout=self.timeout, allow_redirects=False)
-
-        # Proper TAP async redirect
-        if r.status_code in (302, 303):
-
-            job_url = r.headers.get("Location")
-            if job_url:
-                return job_url
-
-        # Some TAP services return 200 + Location
-        job_url = r.headers.get("Location")
-
-        if job_url:
-            return job_url
-
-        raise RuntimeError(
-            f"No TAP job URL returned. "
-            f"Status={r.status_code}. "
-            f"Response:\n{r.text[:500]}"
-        )
-
-    def _poll_job(self, job_url):
-        phase_url = f"{job_url}/phase"
-
-        for _ in range(self.max_polls):
-            r = requests.get(phase_url, timeout=self.timeout)
-            r.raise_for_status()
-            phase = r.text.strip()
-
-            if phase == "COMPLETED":
-                return
-
-            if phase in ("ERROR", "ABORTED"):
-                raise RuntimeError(f"TAP job failed: {phase}")
-
-            time.sleep(self.poll_interval)
-
-        raise TimeoutError("Gaia TAP polling timeout")
-
-    def _fetch_result(self, job_url):
-
-        r = requests.get(f"{job_url}/results/result", timeout=self.timeout)
-        r.raise_for_status()
-
-        return Table.read(io.BytesIO(r.content), format="ascii.csv")
-
 
 GAIA_TAP = GaiaFailoverTAP()
 
@@ -661,6 +497,11 @@ def calculate_current_coordinates(ra, dec, pm_ra, pm_dec, epoch, target_date=Non
     new_ra, new_dec
         The corrected RA and Dec for the source
     """
+    motion = (pm_ra, pm_dec, epoch)
+    if any(np.ma.is_masked(value) or not np.isfinite(value)
+           for value in motion):
+        return np.ma.masked, np.ma.masked
+
     # Set target data
     if target_date is None:
         target_date = Time.now()

--- a/exoctk/contam_visibility/gaia_tap.py
+++ b/exoctk/contam_visibility/gaia_tap.py
@@ -15,6 +15,7 @@ import requests
 
 NORMALIZED_COLUMNS = (
     'source_id',
+    'designation',
     'ra',
     'dec',
     'ref_epoch',
@@ -30,7 +31,8 @@ NORMALIZED_COLUMNS = (
     'classprob_dsc_combmod_galaxy',
     'classprob_dsc_combmod_quasar',
 )
-REQUIRED_COLUMNS = frozenset(('source_id', 'ra', 'dec', 'phot_g_mean_flux'))
+REQUIRED_COLUMNS = frozenset((
+    'source_id', 'designation', 'ra', 'dec', 'phot_g_mean_flux'))
 
 
 @dataclass(frozen=True)
@@ -61,6 +63,7 @@ class GaiaTAPEndpoint:
 _GAIA_COLUMNS = tuple((name, name) for name in NORMALIZED_COLUMNS)
 _VIZIER_COLUMNS = (
     ('"Source"', 'source_id'),
+    ('"DR3Name"', 'designation'),
     ('"RA_ICRS"', 'ra'),
     ('"DE_ICRS"', 'dec'),
     ('"pmRA"', 'pmra'),

--- a/exoctk/contam_visibility/gaia_tap.py
+++ b/exoctk/contam_visibility/gaia_tap.py
@@ -1,0 +1,282 @@
+"""Endpoint-aware Gaia DR3 TAP queries for the contamination tool."""
+
+from dataclasses import dataclass
+import io
+import logging
+import time
+from urllib.parse import urljoin
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from astropy.table import MaskedColumn, Table
+import numpy as np
+import requests
+
+
+NORMALIZED_COLUMNS = (
+    'source_id',
+    'ra',
+    'dec',
+    'ref_epoch',
+    'pmra',
+    'pmdec',
+    'parallax',
+    'astrometric_excess_noise',
+    'phot_g_mean_flux',
+    'phot_g_mean_mag',
+    'bp_rp',
+    'phot_bp_rp_excess_factor',
+    'classprob_dsc_combmod_star',
+    'classprob_dsc_combmod_galaxy',
+    'classprob_dsc_combmod_quasar',
+)
+REQUIRED_COLUMNS = frozenset(('source_id', 'ra', 'dec', 'phot_g_mean_flux'))
+
+
+@dataclass(frozen=True)
+class GaiaTAPEndpoint:
+    """Native query and UWS details for one Gaia TAP service."""
+
+    name: str
+    url: str
+    table: str
+    columns: tuple
+    cone_predicate: str
+    phase_in_url: bool = False
+    start_after_submit: bool = False
+
+    def build_query(self, ra, dec, radius):
+        """Build an explicit native-column cone query."""
+
+        select = ',\n    '.join(
+            f'{native} AS {internal}' for native, internal in self.columns)
+        predicate = self.cone_predicate.format(
+            ra=ra, dec=dec, radius=radius)
+        return (
+            'SELECT\n    ' + select + f'\nFROM {self.table}\n'
+            f'WHERE {predicate}')
+
+
+_GAIA_COLUMNS = tuple((name, name) for name in NORMALIZED_COLUMNS)
+_VIZIER_COLUMNS = (
+    ('"Source"', 'source_id'),
+    ('"RA_ICRS"', 'ra'),
+    ('"DE_ICRS"', 'dec'),
+    ('"pmRA"', 'pmra'),
+    ('"pmDE"', 'pmdec'),
+    ('"Plx"', 'parallax'),
+    ('"epsi"', 'astrometric_excess_noise'),
+    ('"FG"', 'phot_g_mean_flux'),
+    ('"Gmag"', 'phot_g_mean_mag'),
+    ('"BP-RP"', 'bp_rp'),
+    ('"E(BP/RP)"', 'phot_bp_rp_excess_factor'),
+    ('"PSS"', 'classprob_dsc_combmod_star'),
+    ('"PGal"', 'classprob_dsc_combmod_galaxy'),
+    ('"PQSO"', 'classprob_dsc_combmod_quasar'),
+)
+
+GAIA_TAP_ENDPOINTS = (
+    GaiaTAPEndpoint(
+        name='ESAC',
+        url='https://gea.esac.esa.int/tap-server/tap',
+        table='gaiadr3.gaia_source',
+        columns=_GAIA_COLUMNS,
+        cone_predicate=(
+            "1=CONTAINS(POINT('ICRS', ra, dec), "
+            "CIRCLE('ICRS', {ra}, {dec}, {radius}))"),
+    ),
+    GaiaTAPEndpoint(
+        name='NOIRLab',
+        url='https://datalab.noirlab.edu/tap',
+        table='gaia_dr3.gaia_source',
+        columns=_GAIA_COLUMNS,
+        cone_predicate=(
+            "'t'=q3c_radial_query(ra, dec, {ra}, {dec}, {radius})"),
+        phase_in_url=True,
+        start_after_submit=True,
+    ),
+    GaiaTAPEndpoint(
+        name='TAPVizieR',
+        url='https://tapvizier.cds.unistra.fr/TAPVizieR/tap',
+        table='"I/355/gaiadr3"',
+        columns=_VIZIER_COLUMNS,
+        cone_predicate=(
+            "1=CONTAINS(POINT('ICRS', \"RA_ICRS\", \"DE_ICRS\"), "
+            "CIRCLE('ICRS', {ra}, {dec}, {radius}))"),
+    ),
+)
+
+
+class GaiaTAPError(RuntimeError):
+    """A Gaia query failed at one or all configured TAP services."""
+
+
+class GaiaFailoverTAP:
+    """Query endpoint-native Gaia tables and normalize their results."""
+
+    def __init__(
+            self, timeout=30, poll_interval=1.0, max_polls=120,
+            max_retries=3, retry_delay=5, endpoints=GAIA_TAP_ENDPOINTS,
+            session=None):
+        self.endpoints = tuple(endpoints)
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+        self.max_polls = max_polls
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self.session = session or requests
+        self.last_endpoint = None
+
+    def query_region(self, coordinate, width, height=None):
+        """Return a normalized table for the enclosing-circle query."""
+
+        height = width if height is None else height
+        ra = float(coordinate.ra.deg)
+        dec = float(coordinate.dec.deg)
+        width_deg = float(width.to_value(u.deg))
+        height_deg = float(height.to_value(u.deg))
+        radius = 0.5 * np.sqrt(width_deg**2 + height_deg**2)
+        if not np.isfinite(radius) or radius <= 0:
+            raise ValueError(f'Invalid radius: {radius}')
+
+        errors = []
+        last_error = None
+        for retry in range(self.max_retries):
+            for endpoint in self.endpoints:
+                logging.info('[Gaia TAP] Attempting %s (%s)',
+                             endpoint.name, endpoint.url)
+                try:
+                    query = endpoint.build_query(ra, dec, radius)
+                    native = self._run_query(endpoint, query)
+                    result = self._normalize(native, endpoint, coordinate)
+                    self.last_endpoint = endpoint.url
+                    logging.info('[Gaia TAP] %s succeeded with %d rows',
+                                 endpoint.name, len(result))
+                    return result
+                except Exception as exc:
+                    last_error = exc
+                    reason = ' '.join(str(exc).split()) or type(exc).__name__
+                    errors.append(f'{endpoint.name}: {reason}')
+                    logging.warning('[Gaia TAP] %s failed: %s',
+                                    endpoint.name, reason)
+            if retry < self.max_retries - 1:
+                time.sleep(self.retry_delay * (2**retry))
+
+        attempted = '; '.join(errors)
+        raise GaiaTAPError(
+            f'All Gaia TAP endpoints failed: {attempted}') from last_error
+
+    def _run_query(self, endpoint, query):
+        job_url = self._submit_async_job(endpoint, query)
+        self._poll_job(job_url)
+        return self._fetch_result(job_url)
+
+    def _submit_async_job(self, endpoint, query):
+        submit_url = f'{endpoint.url}/async'
+        payload = {
+            'REQUEST': 'doQuery', 'LANG': 'ADQL', 'FORMAT': 'csv',
+            'QUERY': query,
+        }
+        if endpoint.phase_in_url:
+            submit_url += '?PHASE=RUN'
+        else:
+            payload['PHASE'] = 'RUN'
+
+        response = self.session.post(
+            submit_url, data=payload, timeout=self.timeout,
+            allow_redirects=False)
+        response.raise_for_status()
+        location = response.headers.get('Location')
+        if not location:
+            detail = ' '.join(response.text.split())[:300]
+            raise GaiaTAPError(
+                f'no TAP job URL returned (HTTP {response.status_code}): '
+                f'{detail}')
+        job_url = urljoin(response.url, location).rstrip('/')
+
+        if endpoint.start_after_submit:
+            start = self.session.post(
+                f'{job_url}/phase', data={'PHASE': 'RUN'},
+                timeout=self.timeout)
+            start.raise_for_status()
+        return job_url
+
+    def _poll_job(self, job_url):
+        for _ in range(self.max_polls):
+            response = self.session.get(
+                f'{job_url}/phase', timeout=self.timeout)
+            response.raise_for_status()
+            phase = response.text.strip().upper()
+            if phase == 'COMPLETED':
+                return
+            if phase in ('ERROR', 'ABORTED'):
+                detail = ''
+                try:
+                    error = self.session.get(
+                        f'{job_url}/error', timeout=self.timeout)
+                    if error.ok:
+                        detail = ' '.join(error.text.split())[:300]
+                except requests.RequestException:
+                    pass
+                suffix = f': {detail}' if detail else ''
+                raise GaiaTAPError(f'TAP job {phase}{suffix}')
+            time.sleep(self.poll_interval)
+        raise TimeoutError('Gaia TAP polling timeout')
+
+    def _fetch_result(self, job_url):
+        response = self.session.get(
+            f'{job_url}/results/result', timeout=self.timeout)
+        if response.status_code == 404:
+            raise GaiaTAPError('completed TAP job has no result resource')
+        response.raise_for_status()
+        if not response.content.strip():
+            raise GaiaTAPError('completed TAP job returned an empty result')
+        upper = response.content[:2000].upper()
+        if (b'QUERY_STATUS' in upper and b'ERROR' in upper
+                and b'VOTABLE' in upper):
+            raise GaiaTAPError('result resource contains a TAP error document')
+        try:
+            return Table.read(io.BytesIO(response.content), format='ascii.csv')
+        except Exception as exc:
+            raise GaiaTAPError(f'malformed TAP result table: {exc}') from exc
+
+    @staticmethod
+    def _normalize(table, endpoint, coordinate):
+        """Map a native result table onto the contamination schema."""
+
+        result = table.copy(copy_data=True)
+        lower_names = {name.lower(): name for name in result.colnames}
+        native_by_internal = {
+            native.strip('"'): internal
+            for native, internal in endpoint.columns}
+        for native, internal in native_by_internal.items():
+            if internal in result.colnames:
+                continue
+            actual = lower_names.get(native.lower())
+            if actual is not None:
+                result.rename_column(actual, internal)
+
+        missing_required = sorted(REQUIRED_COLUMNS - set(result.colnames))
+        if missing_required:
+            raise GaiaTAPError(
+                'result missing required Gaia columns: '
+                + ', '.join(missing_required))
+
+        for name in NORMALIZED_COLUMNS:
+            if name not in result.colnames:
+                dtype = np.int64 if name == 'source_id' else np.float64
+                result.add_column(MaskedColumn(
+                    np.zeros(len(result), dtype=dtype), mask=True, name=name))
+
+        result = result[list(NORMALIZED_COLUMNS)]
+        try:
+            positions = SkyCoord(
+                np.asarray(result['ra'], dtype=float) * u.deg,
+                np.asarray(result['dec'], dtype=float) * u.deg)
+            distance = coordinate.separation(positions).to_value(u.deg)
+        except Exception as exc:
+            raise GaiaTAPError(
+                f'invalid Gaia coordinates in result: {exc}') from exc
+        result.add_column(distance, name='dist')
+        result.sort(['dist', 'source_id'])
+        return result

--- a/exoctk/contam_visibility/gaia_tap.py
+++ b/exoctk/contam_visibility/gaia_tap.py
@@ -44,6 +44,7 @@ class GaiaTAPEndpoint:
     cone_predicate: str
     phase_in_url: bool = False
     start_after_submit: bool = False
+    constant_columns: tuple = ()
 
     def build_query(self, ra, dec, radius):
         """Build an explicit native-column cone query."""
@@ -103,6 +104,9 @@ GAIA_TAP_ENDPOINTS = (
         cone_predicate=(
             "1=CONTAINS(POINT('ICRS', \"RA_ICRS\", \"DE_ICRS\"), "
             "CIRCLE('ICRS', {ra}, {dec}, {radius}))"),
+        # Gaia DR3 astrometry is at J2016.0; TAPVizieR omits the
+        # catalog-level reference epoch from its native table.
+        constant_columns=(('ref_epoch', 2016.0),),
     ),
 )
 
@@ -255,6 +259,11 @@ class GaiaFailoverTAP:
             actual = lower_names.get(native.lower())
             if actual is not None:
                 result.rename_column(actual, internal)
+
+        for name, value in endpoint.constant_columns:
+            if name not in result.colnames:
+                result.add_column(
+                    np.full(len(result), value, dtype=float), name=name)
 
         missing_required = sorted(REQUIRED_COLUMNS - set(result.colnames))
         if missing_required:

--- a/exoctk/tests/test_gaia_tap.py
+++ b/exoctk/tests/test_gaia_tap.py
@@ -29,6 +29,7 @@ def _native_table(endpoint, source_ids=(30, 10, 20), masked=False):
     count = len(source_ids)
     values = {
         'source_id': source_ids,
+        'designation': [f'Gaia DR3 {source_id}' for source_id in source_ids],
         'ra': [10.001, 10., 10.001][:count],
         'dec': np.full(count, 20.),
         'ref_epoch': np.full(count, 2016.),
@@ -58,10 +59,12 @@ def _native_table(endpoint, source_ids=(30, 10, 20), masked=False):
 
 
 @pytest.mark.parametrize(('index', 'fragments'), [
-    (0, ('FROM gaiadr3.gaia_source', 'CONTAINS', 'ra AS ra')),
-    (1, ('FROM gaia_dr3.gaia_source', 'q3c_radial_query', "'t'=")),
+    (0, ('FROM gaiadr3.gaia_source', 'CONTAINS',
+         'designation AS designation', 'ra AS ra')),
+    (1, ('FROM gaia_dr3.gaia_source', 'q3c_radial_query',
+         'designation AS designation', "'t'=")),
     (2, ('FROM "I/355/gaiadr3"', '"Source" AS source_id',
-         '"RA_ICRS"', '"DE_ICRS"')),
+         '"DR3Name" AS designation', '"RA_ICRS"', '"DE_ICRS"')),
 ])
 def test_endpoint_native_query_construction(index, fragments):
     """Each service receives its own table, columns, and cone syntax."""
@@ -96,6 +99,17 @@ def test_dsc_probabilities_remain_associated_with_source_ids(endpoint):
         result['source_id'], result['classprob_dsc_combmod_star']))
 
     assert probabilities == {10: 0.1, 20: 0.2, 30: 0.3}
+
+
+@pytest.mark.parametrize('endpoint', GAIA_TAP_ENDPOINTS)
+def test_designations_remain_associated_with_source_ids(endpoint):
+    """Plot labels survive endpoint normalization and deterministic sorting."""
+
+    result = GaiaFailoverTAP._normalize(
+        _native_table(endpoint), endpoint, CENTER)
+
+    assert dict(zip(result['source_id'], result['designation'])) == {
+        10: 'Gaia DR3 10', 20: 'Gaia DR3 20', 30: 'Gaia DR3 30'}
 
 
 @pytest.mark.parametrize('endpoint', GAIA_TAP_ENDPOINTS)
@@ -182,14 +196,15 @@ def test_rows_sort_by_distance_then_source_id():
     assert list(result['source_id']) == [10, 20, 30]
 
 
-def test_missing_required_core_column_is_rejected():
+@pytest.mark.parametrize('column', ('phot_g_mean_flux', 'designation'))
+def test_missing_required_core_column_is_rejected(column):
     """A malformed result cannot pass adapter schema validation."""
 
     endpoint = GAIA_TAP_ENDPOINTS[0]
     native = _native_table(endpoint)
-    native.remove_column('phot_g_mean_flux')
+    native.remove_column(column)
 
-    with pytest.raises(GaiaTAPError, match='phot_g_mean_flux'):
+    with pytest.raises(GaiaTAPError, match=column):
         GaiaFailoverTAP._normalize(native, endpoint, CENTER)
 
 

--- a/exoctk/tests/test_gaia_tap.py
+++ b/exoctk/tests/test_gaia_tap.py
@@ -5,6 +5,7 @@ import pytest
 
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
+from astropy.time import Time
 import astropy.units as u
 
 from exoctk.contam_visibility.gaia_tap import (
@@ -14,6 +15,7 @@ from exoctk.contam_visibility.gaia_tap import (
     GaiaTAPError,
 )
 from exoctk.contam_visibility.field_simulator import (
+    _target_source_index,
     calculate_current_coordinates,
 )
 
@@ -106,17 +108,67 @@ def test_masked_values_remain_masked(endpoint):
 
     assert np.ma.is_masked(result['parallax'][row])
     if endpoint.name == 'TAPVizieR':
-        assert np.all(result['ref_epoch'].mask)
+        assert np.all(result['ref_epoch'] == 2016.)
+        assert not np.any(np.ma.getmaskarray(result['ref_epoch']))
 
 
-def test_unavailable_reference_epoch_skips_proper_motion_correction():
-    """A masked optional epoch cannot break downstream source handling."""
+def test_vizier_supplies_fixed_gaia_dr3_reference_epoch():
+    """Every TAPVizieR source receives the catalog-level J2016.0 epoch."""
+
+    endpoint = GAIA_TAP_ENDPOINTS[2]
+    result = GaiaFailoverTAP._normalize(
+        _native_table(endpoint, source_ids=(11, 22, 33)), endpoint, CENTER)
+
+    assert result['ref_epoch'].dtype.kind == 'f'
+    assert np.all(np.isfinite(result['ref_epoch']))
+    assert dict(zip(result['source_id'], result['ref_epoch'])) == {
+        11: 2016., 22: 2016., 33: 2016.}
+
+
+def test_vizier_proper_motion_propagates_from_j2016():
+    """Omitted native epoch metadata does not skip proper-motion handling."""
+
+    endpoint = GAIA_TAP_ENDPOINTS[2]
+    native = _native_table(endpoint, source_ids=(11,))
+    native['RA_ICRS'] = [10.]
+    native['DE_ICRS'] = [0.]
+    native['pmRA'] = [360000.]
+    native['pmDE'] = [180000.]
+    result = GaiaFailoverTAP._normalize(native, endpoint, CENTER)
 
     ra, dec = calculate_current_coordinates(
-        10., 20., 1., 1., np.ma.masked, target_date=2026)
+        result['ra'][0], result['dec'][0], result['pmra'][0],
+        result['pmdec'][0], result['ref_epoch'][0], target_date=2026)
 
-    assert np.ma.is_masked(ra)
-    assert np.ma.is_masked(dec)
+    elapsed_years = (
+        Time('2026-01-01') - Time('2016-01-01')).to_value(u.year)
+    assert ra == pytest.approx(10. + 0.1 * elapsed_years)
+    assert dec == pytest.approx(0.05 * elapsed_years)
+
+
+def test_all_endpoints_identify_same_moving_target():
+    """J2016.0 normalization preserves high-proper-motion target matching."""
+
+    target_id = 101
+    input_coordinate = SkyCoord(10. * u.deg, 20. * u.deg)
+    catalog_ra = 10. + 3600. / 3.6e6 * 16. / np.cos(np.deg2rad(20.))
+    normalized = []
+    for endpoint in GAIA_TAP_ENDPOINTS:
+        native = _native_table(endpoint, source_ids=(target_id, 202))
+        internal_to_native = {
+            internal: native_name.strip('"')
+            for native_name, internal in endpoint.columns}
+        native[internal_to_native['ra']] = [catalog_ra, 10.001]
+        native[internal_to_native['dec']] = [20., 20.]
+        native[internal_to_native['pmra']] = [3600., 0.]
+        native[internal_to_native['pmdec']] = [0., 0.]
+        normalized.append(GaiaFailoverTAP._normalize(
+            native, endpoint, input_coordinate))
+
+    identified = [
+        table['source_id'][_target_source_index(table, input_coordinate)]
+        for table in normalized]
+    assert identified == [target_id, target_id, target_id]
 
 
 def test_rows_sort_by_distance_then_source_id():

--- a/exoctk/tests/test_gaia_tap.py
+++ b/exoctk/tests/test_gaia_tap.py
@@ -1,0 +1,280 @@
+"""Tests for endpoint-aware Gaia TAP querying."""
+
+import numpy as np
+import pytest
+
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
+import astropy.units as u
+
+from exoctk.contam_visibility.gaia_tap import (
+    GAIA_TAP_ENDPOINTS,
+    NORMALIZED_COLUMNS,
+    GaiaFailoverTAP,
+    GaiaTAPError,
+)
+from exoctk.contam_visibility.field_simulator import (
+    calculate_current_coordinates,
+)
+
+
+CENTER = SkyCoord(10. * u.deg, 20. * u.deg)
+
+
+def _native_table(endpoint, source_ids=(30, 10, 20), masked=False):
+    """Return a small table using an endpoint's native column names."""
+
+    count = len(source_ids)
+    values = {
+        'source_id': source_ids,
+        'ra': [10.001, 10., 10.001][:count],
+        'dec': np.full(count, 20.),
+        'ref_epoch': np.full(count, 2016.),
+        'pmra': np.arange(count, dtype=float),
+        'pmdec': np.arange(count, dtype=float),
+        'parallax': np.arange(count, dtype=float),
+        'astrometric_excess_noise': np.zeros(count),
+        'phot_g_mean_flux': np.full(count, 100.),
+        'phot_g_mean_mag': np.full(count, 12.),
+        'bp_rp': np.full(count, 1.),
+        'phot_bp_rp_excess_factor': np.full(count, 1.),
+        'classprob_dsc_combmod_star': np.asarray(source_ids) / 100.,
+        'classprob_dsc_combmod_galaxy': np.asarray(source_ids) / 1000.,
+        'classprob_dsc_combmod_quasar': np.asarray(source_ids) / 10000.,
+    }
+    internal_to_native = {
+        internal: native.strip('"') for native, internal in endpoint.columns}
+    columns = {}
+    for internal, column in values.items():
+        native = internal_to_native.get(internal)
+        if native is not None:
+            columns[native] = column
+    table = Table(columns, masked=masked)
+    if masked:
+        table[internal_to_native['parallax']].mask[0] = True
+    return table
+
+
+@pytest.mark.parametrize(('index', 'fragments'), [
+    (0, ('FROM gaiadr3.gaia_source', 'CONTAINS', 'ra AS ra')),
+    (1, ('FROM gaia_dr3.gaia_source', 'q3c_radial_query', "'t'=")),
+    (2, ('FROM "I/355/gaiadr3"', '"Source" AS source_id',
+         '"RA_ICRS"', '"DE_ICRS"')),
+])
+def test_endpoint_native_query_construction(index, fragments):
+    """Each service receives its own table, columns, and cone syntax."""
+
+    query = GAIA_TAP_ENDPOINTS[index].build_query(10., 20., 0.1)
+
+    assert 'SELECT *' not in query
+    assert all(fragment in query for fragment in fragments)
+
+
+@pytest.mark.parametrize('endpoint', GAIA_TAP_ENDPOINTS)
+def test_endpoint_results_share_normalized_schema(endpoint):
+    """Native endpoint tables normalize to one forward-compatible contract."""
+
+    native = _native_table(endpoint)
+    result = GaiaFailoverTAP._normalize(native, endpoint, CENTER)
+
+    assert result.colnames == list(NORMALIZED_COLUMNS) + ['dist']
+    assert all(name in result.colnames for name in (
+        'classprob_dsc_combmod_star',
+        'classprob_dsc_combmod_galaxy',
+        'classprob_dsc_combmod_quasar'))
+
+
+@pytest.mark.parametrize('endpoint', GAIA_TAP_ENDPOINTS)
+def test_dsc_probabilities_remain_associated_with_source_ids(endpoint):
+    """Renaming and deterministic sorting do not misalign DSC values."""
+
+    result = GaiaFailoverTAP._normalize(
+        _native_table(endpoint), endpoint, CENTER)
+    probabilities = dict(zip(
+        result['source_id'], result['classprob_dsc_combmod_star']))
+
+    assert probabilities == {10: 0.1, 20: 0.2, 30: 0.3}
+
+
+@pytest.mark.parametrize('endpoint', GAIA_TAP_ENDPOINTS)
+def test_masked_values_remain_masked(endpoint):
+    """Native nulls and unavailable optional fields stay masked."""
+
+    result = GaiaFailoverTAP._normalize(
+        _native_table(endpoint, masked=True), endpoint, CENTER)
+    row = np.flatnonzero(result['source_id'] == 30)[0]
+
+    assert np.ma.is_masked(result['parallax'][row])
+    if endpoint.name == 'TAPVizieR':
+        assert np.all(result['ref_epoch'].mask)
+
+
+def test_unavailable_reference_epoch_skips_proper_motion_correction():
+    """A masked optional epoch cannot break downstream source handling."""
+
+    ra, dec = calculate_current_coordinates(
+        10., 20., 1., 1., np.ma.masked, target_date=2026)
+
+    assert np.ma.is_masked(ra)
+    assert np.ma.is_masked(dec)
+
+
+def test_rows_sort_by_distance_then_source_id():
+    """Equal angular separations use source ID as a stable tie breaker."""
+
+    endpoint = GAIA_TAP_ENDPOINTS[0]
+    native = _native_table(endpoint, source_ids=(30, 10, 20))
+    native['ra'] = [10.001, 10., 10.001]
+    result = GaiaFailoverTAP._normalize(native, endpoint, CENTER)
+
+    assert list(result['source_id']) == [10, 20, 30]
+
+
+def test_missing_required_core_column_is_rejected():
+    """A malformed result cannot pass adapter schema validation."""
+
+    endpoint = GAIA_TAP_ENDPOINTS[0]
+    native = _native_table(endpoint)
+    native.remove_column('phot_g_mean_flux')
+
+    with pytest.raises(GaiaTAPError, match='phot_g_mean_flux'):
+        GaiaFailoverTAP._normalize(native, endpoint, CENTER)
+
+
+@pytest.mark.parametrize('failure_count, expected_endpoint', [
+    (1, 'NOIRLab'),
+    (2, 'TAPVizieR'),
+])
+def test_query_region_fails_over_to_next_endpoint(
+        monkeypatch, failure_count, expected_endpoint):
+    """Transport/schema failures advance through endpoint priority order."""
+
+    adapter = GaiaFailoverTAP(max_retries=1)
+    attempts = []
+
+    def run(endpoint, query):
+        attempts.append(endpoint.name)
+        if len(attempts) <= failure_count:
+            raise GaiaTAPError('synthetic failure')
+        return _native_table(endpoint)
+
+    monkeypatch.setattr(adapter, '_run_query', run)
+    result = adapter.query_region(CENTER, 1. * u.arcmin)
+
+    assert attempts[-1] == expected_endpoint
+    assert adapter.last_endpoint == next(
+        item.url for item in GAIA_TAP_ENDPOINTS
+        if item.name == expected_endpoint)
+    assert len(result) == 3
+
+
+def test_all_endpoint_failures_are_summarized(monkeypatch):
+    """Total failure reports every service and retains exception chaining."""
+
+    adapter = GaiaFailoverTAP(max_retries=1)
+
+    def fail(endpoint, query):
+        raise GaiaTAPError(f'{endpoint.name} unavailable')
+
+    monkeypatch.setattr(adapter, '_run_query', fail)
+    with pytest.raises(GaiaTAPError) as caught:
+        adapter.query_region(CENTER, 1. * u.arcmin)
+
+    assert all(endpoint.name in str(caught.value)
+               for endpoint in GAIA_TAP_ENDPOINTS)
+    assert caught.value.__cause__ is not None
+
+
+class _Response:
+    def __init__(self, text='', content=None, status=200, headers=None,
+                 url='https://example.test/async'):
+        self.text = text
+        self.content = text.encode() if content is None else content
+        self.status_code = status
+        self.headers = headers or {}
+        self.url = url
+        self.ok = status < 400
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f'HTTP {self.status_code}')
+
+
+class _Session:
+    def __init__(self, responses=()):
+        self.responses = iter(responses)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append(('get', url, kwargs))
+        return next(self.responses)
+
+    def post(self, url, **kwargs):
+        self.calls.append(('post', url, kwargs))
+        return next(self.responses)
+
+
+@pytest.mark.parametrize('phase', ('ERROR', 'ABORTED'))
+def test_terminal_tap_failure_phases_are_rejected(phase):
+    """Terminal unsuccessful UWS phases fail without fetching a result."""
+
+    session = _Session((
+        _Response(text=phase),
+        _Response(text='service detail'),
+    ))
+    adapter = GaiaFailoverTAP(session=session, max_polls=1)
+
+    with pytest.raises(GaiaTAPError, match=phase):
+        adapter._poll_job('https://example.test/job/1')
+
+
+def test_polling_timeout_is_finite():
+    """A perpetually executing UWS job reaches the configured timeout."""
+
+    session = _Session((_Response(text='EXECUTING'),) * 2)
+    adapter = GaiaFailoverTAP(
+        session=session, max_polls=2, poll_interval=0)
+
+    with pytest.raises(TimeoutError, match='polling timeout'):
+        adapter._poll_job('https://example.test/job/1')
+
+
+def test_missing_result_resource_is_rejected():
+    """A completed job must expose a retrievable result resource."""
+
+    adapter = GaiaFailoverTAP(
+        session=_Session((_Response(status=404),)))
+
+    with pytest.raises(GaiaTAPError, match='no result resource'):
+        adapter._fetch_result('https://example.test/job/1')
+
+
+def test_malformed_table_is_rejected_before_find_sources(monkeypatch):
+    """A parseable but unexpected table cannot become simulator input."""
+
+    adapter = GaiaFailoverTAP(
+        endpoints=(GAIA_TAP_ENDPOINTS[0],), max_retries=1)
+    monkeypatch.setattr(
+        adapter, '_run_query', lambda endpoint, query: Table({'not': [1]}))
+
+    with pytest.raises(GaiaTAPError, match='missing required Gaia columns'):
+        adapter.query_region(CENTER, 1. * u.arcmin)
+
+
+def test_noirlab_uses_native_job_start_sequence():
+    """NOIRLab receives its phase URL and explicit UWS start request."""
+
+    endpoint = GAIA_TAP_ENDPOINTS[1]
+    created = _Response(
+        status=303, headers={'Location': '/tap/async/42'},
+        url=f'{endpoint.url}/async?PHASE=RUN')
+    session = _Session((created, _Response()))
+    adapter = GaiaFailoverTAP(session=session)
+
+    job_url = adapter._submit_async_job(endpoint, 'SELECT source_id')
+
+    assert job_url == 'https://datalab.noirlab.edu/tap/async/42'
+    assert session.calls[0][1].endswith('/async?PHASE=RUN')
+    assert 'PHASE' not in session.calls[0][2]['data']
+    assert session.calls[1][1].endswith('/tap/async/42/phase')
+    assert session.calls[1][2]['data'] == {'PHASE': 'RUN'}


### PR DESCRIPTION
## Summary

Make Gaia TAP failover work across ESAC, NOIRLab Data Lab, and TAPVizieR.

The previous code reused an ESAC-specific query and TAP workflow for every service, even though the endpoints use different table names, column names, cone-search syntax, and job handling.

This PR adds endpoint-specific adapters that:

- build native queries for each service;
- normalize results to one internal Astropy schema;
- preserve masked values and validate required columns;
- calculate and sort angular distances consistently;
- fail over cleanly when an endpoint fails.

TAPVizieR does not expose `ref_epoch`, so its Gaia DR3 results are assigned the documented catalog epoch J2016.0 for proper-motion propagation.

## Validation

- Gaia TAP tests: `26 passed`
- Complete contamination module: `27 passed`
- Live K2-18 queries returned the same 74 source IDs from all three services
- Flake8 and `git diff --check` passed

This PR is independent of #725, but already normalizes the Gaia DSC probability columns that #725 will use. It does not change source classification, SDSS matching, cache behavior, order-0 calibration, or rendering policy.