### PR TITLE
Add living-cache regression coverage

### DIFF
--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -30,6 +30,7 @@ import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
+import h5py
 import numpy as np
 import pytest
 import pysiaf
@@ -308,6 +309,63 @@ def test_miri_position_angle_failure_is_raised(monkeypatch):
     with pytest.raises(RuntimeError, match='synthetic PA failure'):
         field_simulator.field_simulation(
             ra=10., dec=20., aperture=aperture_name)
+
+
+def test_field_simulation_updates_default_living_cache(tmp_path, monkeypatch):
+    """A newly calculated named target is saved to its aperture cache."""
+
+    aperture_name = 'NIS_SUBSTRIP96'
+    full_name = field_simulator.APERTURES[aperture_name]['full']
+
+    class FakeFullAperture:
+        @staticmethod
+        def corners(frame):
+            assert frame == 'det'
+            return np.array([0., 1.]), np.array([0., 1.])
+
+    class FakeScienceAperture:
+        XSciSize = 2
+        YSciSize = 2
+
+    class FakeSiaf:
+        apertures = {
+            full_name: FakeFullAperture(),
+            aperture_name: FakeScienceAperture(),
+        }
+
+    positions = DataFrame({
+        'V3PA_min_pa_angle': [0.],
+        'V3PA_nominal_angle': [0.],
+        'V3PA_max_pa_angle': [0.],
+    })
+    monkeypatch.setenv('EXOCTK_CONTAM_CACHE', str(tmp_path))
+    monkeypatch.setattr(precompute, '_get_shape', lambda aperture: (1, 2, 2))
+    monkeypatch.setattr(field_simulator, 'check_for_data', lambda *args: None)
+    monkeypatch.setattr(field_simulator, 'get_canonical_name', lambda name: name)
+    monkeypatch.setattr(
+        field_simulator, 'resolve_target', lambda name: (10., 20.))
+    monkeypatch.setattr(field_simulator.pysiaf, 'Siaf', lambda inst: FakeSiaf())
+    monkeypatch.setattr(
+        field_simulator, 'find_sources', lambda *args, **kwargs: Table())
+    monkeypatch.setattr(
+        field_simulator, 'get_exoplanet_positions',
+        lambda *args, **kwargs: positions)
+    monkeypatch.setattr(
+        field_simulator, 'calc_v3pa',
+        lambda pa, **kwargs: {
+            'pa': int(pa),
+            'target_traces': [np.ones((2, 2))],
+            'contaminants': np.full((2, 2), 0.25),
+        })
+
+    field_simulator.field_simulation(
+        targname='Synthetic target', aperture=aperture_name)
+
+    cache = tmp_path / f'{aperture_name}_db.h5'
+    assert cache.exists()
+    with h5py.File(cache, 'r') as handle:
+        assert handle['Synthetic target'].attrs['filled']
+        assert list(handle['Synthetic target']['plane_index'][:]) == [0]
 
 
 def test_resolve_target():


### PR DESCRIPTION
Verify that a newly calculated named target is written to the default aperture cache and marked as populated.