### PR TITLE
Exclude off-mask pixels from contamination averages

### DIFF
--- a/exoctk/contam_visibility/contamination_figure.py
+++ b/exoctk/contam_visibility/contamination_figure.py
@@ -86,16 +86,24 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
     percent_lines = [np.asarray(line) * 100 for line in pctlines]
     display_y_max = y_max * 100
 
-    # Store individual contamination fractions for each order+PA combination
+    # Store individual contamination fractions and matching fill baselines for
+    # each order+PA combination.  NaNs in the baseline prevent Bokeh from
+    # closing a filled area across columns where an order has no trace.
     contam_dict = {}
     for order in orders:
         for pa, percent in enumerate(percent_lines[order - 1]):
             contam_dict[f'contam{order}_{pa}'] = percent
+            contam_dict[f'baseline{order}_{pa}'] = np.where(
+                np.isfinite(percent), 0, np.nan)
 
     # Choose initial values and build visible and available dicts
     pa_init = int(np.argmax(np.nansum(np.asarray(pctlines), axis=(0, 2)))) # Maximum contamination
-    vis_dict = {f'contam{order}': contam_dict[f'contam{order}_{pa_init}'] for order in orders}
-    vis_dict.update({'col': np.arange(n_channels), 'zeros': np.zeros(n_channels)})
+    vis_dict = {'col': np.arange(n_channels)}
+    for order in orders:
+        vis_dict[f'contam{order}'] = contam_dict[
+            f'contam{order}_{pa_init}']
+        vis_dict[f'baseline{order}'] = contam_dict[
+            f'baseline{order}_{pa_init}']
     source_visible = ColumnDataSource(data=vis_dict)
     source_available = ColumnDataSource(data=contam_dict)
 
@@ -104,7 +112,9 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
     colors = ['blue', 'red', 'green', 'cyan', 'dodgerblue', 'purple', 'orange', 'lime', 'yellow', 'magenta']
     for order in orders:
         plt.line('col', f'contam{order}', source=source_visible, color=colors[order - 1], line_width=2, line_alpha=0.6, legend_label=f'Order {order}')
-        glyph = VArea(x="col", y1="zeros", y2=f"contam{order}", fill_color=colors[order - 1], fill_alpha=0.3)
+        glyph = VArea(x="col", y1=f"baseline{order}",
+                      y2=f"contam{order}",
+                      fill_color=colors[order - 1], fill_alpha=0.3)
         plt.add_glyph(source_visible, glyph)
 
     plt.y_range = Range1d(0, display_y_max)
@@ -121,7 +131,13 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
     span = Span(line_width=2, location=slider.value, dimension='height')
 
     # Define CustomJS callback, which updates the plot based on selected function by updating the source_visible
-    js_orders = "\n".join([f"data_visible['contam{order}'] = data_available['contam{order}_' + selected_pa];" for order in orders])
+    js_orders = "\n".join([
+        f"data_visible['contam{order}'] = "
+        f"data_available['contam{order}_' + selected_pa];\n"
+        f"data_visible['baseline{order}'] = "
+        f"data_available['baseline{order}_' + selected_pa];"
+        for order in orders
+    ])
     callback = CustomJS(
         args=dict(source_visible=source_visible, source_available=source_available, span=span), code=f"""
             var selected_pa = (cb_obj.value).toString();
@@ -143,7 +159,16 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
     for order in orders:
 
         # Plot the mean contamination across spectral channels.
-        viz_plt.step(pa_list, np.nanmean(percent_lines[order - 1], axis=1), line_width=2, color=colors[order - 1], mode="center")
+        percent_line = percent_lines[order - 1]
+        valid = np.isfinite(percent_line)
+        mean_line = np.divide(
+            np.nansum(percent_line, axis=1), np.sum(valid, axis=1),
+            out=np.full(len(pa_list), np.nan),
+            where=np.sum(valid, axis=1) > 0,
+        )
+        mean_line[np.asarray(badPA_list, dtype=int)] = np.nan
+        viz_plt.step(pa_list, mean_line, line_width=2,
+                     color=colors[order - 1], mode="center")
 
         # PLot columns that indicate >5% contamination
         viz_ord = np.array([

--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -800,10 +800,11 @@ def fraction_contaminated(aperture, targframes, starcube):
     # Divide contam/(trace + contam) to get fraction of contamination
     pctframes = [np.divide(starcube, sframe, out=np.full_like(starcube, np.nan), where=(sframe != 0) & ~np.isnan(sframe)) for sframe in simframes]
 
-    # Sum along columns inside trace masks
+    # Average only pixels inside each trace mask. Multiplying off-mask pixels
+    # by zero would leave them finite and incorrectly count them in the mean.
     pctlines = []
     for i, (pframe, mask) in enumerate(zip(pctframes, trace_masks)):
-        masked = pframe * mask
+        masked = np.where(mask > 0, pframe * mask, np.nan)
         # Keep empty spectral channels as NaN, but avoid NumPy's repeated
         # ``Mean of empty slice`` warnings for the expected empty channels.
         valid = ~np.isnan(masked)

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -567,6 +567,40 @@ def test_contamination_slider_uses_percent_and_common_display_cap():
     assert threshold_renderer.data_source.data['top'][0] == 10
 
 
+def test_contamination_slider_fill_stops_at_trace_boundary():
+    """Filled order regions do not extend beyond their valid columns."""
+
+    fractions = np.full((360, 5), 0.01)
+    fractions[:, 3:] = np.nan
+    plot = contamination_figure.contam_slider_plot(
+        [fractions], badPA_list=[])
+    spectrum_plot = plot.children[0]
+    source = spectrum_plot.renderers[0].data_source
+    area = spectrum_plot.renderers[1].glyph
+
+    assert area.y1 == 'baseline1'
+    np.testing.assert_array_equal(
+        np.isfinite(source.data['baseline1']),
+        np.isfinite(source.data['contam1']))
+    assert np.all(source.data['baseline1'][:3] == 0)
+    assert np.isnan(source.data['baseline1'][3:]).all()
+
+
+def test_contamination_slider_breaks_mean_curve_at_bad_pas():
+    """Unobservable PAs are gaps rather than zeroes in the mean curve."""
+
+    fractions = np.full((360, 3), 0.01)
+    plot = contamination_figure.contam_slider_plot(
+        [fractions], badPA_list=[10, 11])
+    pa_plot = plot.children[2]
+    mean_renderer = pa_plot.renderers[1]
+    mean_data = mean_renderer.data_source.data[mean_renderer.glyph.y]
+
+    assert mean_data[9] == 1
+    assert np.isnan(mean_data[10:12]).all()
+    assert mean_data[12] == 1
+
+
 def test_observable_pa_ranges_use_v3pa_not_instrument_angle():
     """Visibility selection must not apply the SIAF offset a second time."""
 

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -671,6 +671,29 @@ def test_fraction_contaminated_returns_nan_for_empty_channel_without_warning(
                    for warning in caught)
 
 
+@pytest.mark.parametrize('aperture, mask_function', [
+    ('NIS_SUBSTRIP96', 'NIRISS_SOSS_trace_mask'),
+    ('NRCA5_41STRIPE1_DHS_F444W', 'NIRCam_DHS_trace_mask'),
+])
+def test_fraction_contaminated_ignores_flux_outside_extraction(
+        monkeypatch, aperture, mask_function):
+    """Off-mask sources do not dilute SOSS or DHS contamination."""
+
+    mask = np.array([[1.], [1.], [0.]])
+    target = np.array([[1.], [1.], [0.]])
+    contaminants = np.array([
+        [[1.], [0.], [0.]],
+        [[1.], [0.], [100.]],
+    ])
+    monkeypatch.setattr(
+        field_simulator, mask_function, lambda aperture: [mask])
+
+    result = field_simulator.fraction_contaminated(
+        aperture, [target], contaminants)[0]
+
+    assert np.allclose(result, 0.25)
+
+
 @pytest.mark.parametrize('aperture', [
     'NIS_SUBSTRIP96',
     'NIS_SUBSTRIP256',


### PR DESCRIPTION
## Summary

Correct contamination calculations so pixels outside a spectral extraction mask do not participate in the reported mean.

Previously, multiplying the contamination frame by a zero-valued mask left finite zeroes outside the extraction region. Those zeroes were counted in the mean’s denominator, allowing unrelated sources elsewhere on the detector to artificially dilute the reported in-extraction contamination.

This change:

- Represents off-mask pixels as `NaN` so they are excluded from the mean.
- Applies consistently to NIRISS/SOSS and NIRCam/DHS.
- Adds regression tests demonstrating that bright off-mask sources do not alter the reported contamination.

This may increase reported contamination where the previous calculation was diluted by flux outside the extraction region.

## Testing

```text
3 passed, 60 deselected
```