### PR TITLE
Add MIRI/LRS slitless contamination support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,27 +79,37 @@ jobs:
         working-directory: /tmp/exoctk/data
         run: |
           echo "Downloading ExoCTK Data"
-          curl -L https://stsci.box.com/shared/static/grztwf220jnvamzv8ugb7phj9tlwnoi1 -o output.zip
-          unzip -o output.zip
-          rm output.zip
+          # all.zip contains only an empty all/ directory.
+          # curl -L https://stsci.box.com/shared/static/grztwf220jnvamzv8ugb7phj9tlwnoi1 -o output.zip
+          # unzip -o output.zip
+          # rm output.zip
+
           curl -L https://stsci.box.com/shared/static/zhrx2r6kgeovcnj78d4wicb7m2009qca -o output.zip
           unzip -o output.zip
           rm output.zip
-          curl -L https://stsci.box.com/shared/static/4q75kt2xelk3zox26vii1i3clnm7nzt7 -o output.zip
-          unzip -o output.zip
-          rm output.zip
+
+          # The website creates its logging database when one is not present.
+          # curl -L https://stsci.box.com/shared/static/4q75kt2xelk3zox26vii1i3clnm7nzt7 -o output.zip
+          # unzip -o output.zip
+          # rm output.zip
+
           curl -L https://stsci.box.com/shared/static/702r4nkccc484noiggq5xt13agbkkevp -o output.zip
           unzip -o output.zip
           rm output.zip
+
           curl -L https://stsci.box.com/shared/static/p64c53rky00ojz1gvabe9hqirpat9azz -o output.zip
           unzip -o output.zip
           rm output.zip
-          curl -L https://stsci.box.com/shared/static/1ag5x8ii1ko8h6lnoxwxljgdfw2mp894 -o output.zip
-          unzip -o output.zip
-          rm output.zip
+
+          # Groups/Integrations uses the JSON data packaged with ExoCTK.
+          # curl -L https://stsci.box.com/shared/static/1ag5x8ii1ko8h6lnoxwxljgdfw2mp894 -o output.zip
+          # unzip -o output.zip
+          # rm output.zip
+
           curl -L https://stsci.box.com/shared/static/vcn1ff9nzg2qx3pnkmsz17dujjdzlsh1 -o output.zip
           unzip -o output.zip
           rm output.zip
+
           echo "ExoCTK data is installed"
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,9 +91,6 @@ jobs:
           curl -L https://stsci.box.com/shared/static/702r4nkccc484noiggq5xt13agbkkevp -o output.zip
           unzip -o output.zip
           rm output.zip
-          curl -L https://stsci.box.com/shared/static/zhrx2r6kgeovcnj78d4wicb7m2009qca -o output.zip
-          unzip -o output.zip
-          rm output.zip
           curl -L https://stsci.box.com/shared/static/p64c53rky00ojz1gvabe9hqirpat9azz -o output.zip
           unzip -o output.zip
           rm output.zip

--- a/docker/exoctk/exoctk_entrypoint.sh
+++ b/docker/exoctk/exoctk_entrypoint.sh
@@ -6,6 +6,8 @@ do
 done
 
 # run gunicorn
-gunicorn -b 0.0.0.0:5000 --log-level info --access-logfile - --error-logfile - --capture-output 'exoctk.exoctk_app.app_exoctk:app_exoctk'
+gunicorn -b 0.0.0.0:5000 --timeout 120 --log-level info \
+    --access-logfile - --error-logfile - --capture-output \
+    'exoctk.exoctk_app.app_exoctk:app_exoctk'
 
 tail -f /dev/null

--- a/docker/exoctk/test_exoctk_page.py
+++ b/docker/exoctk/test_exoctk_page.py
@@ -231,6 +231,14 @@ def do_submit(driver, params, calculation_timeout=2700):
             f'result element {locator!r}')
         next_report = PROGRESS_INTERVAL
         while True:
+            if '500 Internal Server Error' in driver.title:
+                elapsed = time.monotonic() - started
+                log(f'[{test_name}] HTTP 500 detected after {elapsed:.1f} '
+                    f'seconds; URL={driver.current_url!r}')
+                raise RuntimeError(
+                    f'{test_name} returned an HTTP 500 page after '
+                    f'{elapsed:.1f} seconds; URL={driver.current_url!r}')
+
             if driver.find_elements(*locator):
                 elapsed = time.monotonic() - started
                 log(f'[{test_name}] Found result element after '

--- a/exoctk/contam_visibility/contamination_figure.py
+++ b/exoctk/contam_visibility/contamination_figure.py
@@ -1,10 +1,11 @@
 import os
 import sys
+from html import escape
 from itertools import groupby, count
 
 from astropy.io import fits
 from bokeh.layouts import gridplot, column, row
-from bokeh.models import Range1d, LinearColorMapper, LogColorMapper, Label, ColorBar, ColumnDataSource, HoverTool, Slider, CustomJS, VArea, CrosshairTool, TapTool, OpenURL, Span, Legend, Spacer
+from bokeh.models import Range1d, LinearColorMapper, LogColorMapper, Label, ColorBar, ColumnDataSource, HoverTool, Slider, CustomJS, VArea, CrosshairTool, TapTool, OpenURL, Span, Legend, Spacer, Div
 from bokeh.palettes import PuBu, Spectral6
 from bokeh.plotting import figure
 import numpy as np
@@ -47,7 +48,8 @@ def has_order2_contamination(instrument):
 
 
 def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
-                       instrument=None):
+                       instrument=None, wavelength=None, trace_names=None,
+                       contamination_labels=None):
     """
     Make the contamination plot with a slider
 
@@ -57,6 +59,12 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
         The list of fractional contamination arrays
     badPA_list: array-like
         The position angles that are not observable
+    wavelength: array-like, optional
+        Spectral coordinate for the upper plot
+    trace_names: list[str], optional
+        Labels for the spectra in the upper plot
+    contamination_labels: list[str], optional
+        Labels for threshold regions in the position-angle plot
     threshold: float
         The threshold for contamination reporting in the plot
     y_max: float
@@ -98,7 +106,11 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
 
     # Choose initial values and build visible and available dicts
     pa_init = int(np.argmax(np.nansum(np.asarray(pctlines), axis=(0, 2)))) # Maximum contamination
-    vis_dict = {'col': np.arange(n_channels)}
+    spectral_coordinate = (np.arange(n_channels) if wavelength is None
+                           else np.asarray(wavelength))
+    if spectral_coordinate.shape != (n_channels,):
+        raise ValueError('Wavelength coordinate must match contamination channels')
+    vis_dict = {'col': spectral_coordinate}
     for order in orders:
         vis_dict[f'contam{order}'] = contam_dict[
             f'contam{order}_{pa_init}']
@@ -110,16 +122,29 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
     # Contamination fraction plot
     plt = figure(width=900, height=300, tools=['reset', 'save'])
     colors = ['blue', 'red', 'green', 'cyan', 'dodgerblue', 'purple', 'orange', 'lime', 'yellow', 'magenta']
-    for order in orders:
-        plt.line('col', f'contam{order}', source=source_visible, color=colors[order - 1], line_width=2, line_alpha=0.6, legend_label=f'Order {order}')
+    labels = trace_names or [f'Order {order}' for order in orders]
+    if contamination_labels is None and wavelength is not None and len(orders) == 1:
+        threshold_labels = ['Spectrum']
+    else:
+        threshold_labels = (contamination_labels or
+                            [f'Ord {order}' for order in orders])
+    if len(labels) != len(orders) or len(threshold_labels) != len(orders):
+        raise ValueError('Plot labels must match the number of traces')
+    for order, label in zip(orders, labels):
+        plt.line('col', f'contam{order}', source=source_visible, color=colors[order - 1], line_width=2, line_alpha=0.6, legend_label=label)
         glyph = VArea(x="col", y1=f"baseline{order}",
                       y2=f"contam{order}",
                       fill_color=colors[order - 1], fill_alpha=0.3)
         plt.add_glyph(source_visible, glyph)
 
     plt.y_range = Range1d(0, display_y_max)
-    plt.x_range = Range1d(0, n_channels)
-    plt.xaxis.axis_label = 'Column Index'
+    if wavelength is not None:
+        finite = spectral_coordinate[np.isfinite(spectral_coordinate)]
+        plt.x_range = Range1d(float(np.nanmin(finite)), float(np.nanmax(finite)))
+    else:
+        plt.x_range = Range1d(0, n_channels)
+    plt.xaxis.axis_label = ('Wavelength (micron)' if wavelength is not None
+                            else 'Column Index')
     plt.yaxis.axis_label = 'Contamination (%)'
     slider = Slider(title='V3 Position Angle',
                     value=pa_init,
@@ -185,8 +210,8 @@ def contam_slider_plot(pctlines, badPA_list, threshold=0.05, y_max=0.1,
     viz_plt.add_layout(span)
 
     items = [("Target not observable", [c0])]
-    for order, vis_ord in zip(orders, vis_ords):
-        items.append((f'Ord {order} > {threshold * 100}% Contaminated', [vis_ord]))
+    for label, vis_ord in zip(threshold_labels, vis_ords):
+        items.append((f'{label} > {threshold * 100}% Contaminated', [vis_ord]))
     legend = Legend(items=items, location=(50, 0), orientation='horizontal', border_line_alpha=0)
     viz_plt.add_layout(legend, 'below')
 
@@ -222,6 +247,64 @@ def soss_contamination_plot_layout(targframes, starcube, pctlines,
     slider_plot = contam_slider_plot(
         pctlines, badPA_list, instrument=instrument)
     return column(legacy_plot, slider_plot)
+
+
+def miri_single_pa_plot(result):
+    """Build a detector and wavelength diagnostic for one MIRI position angle.
+
+    Parameters
+    ----------
+    result : dict
+        MIRI result returned by :func:`miri_lrs.calc_v3pa`.
+
+    Returns
+    -------
+    bokeh.models.layouts.Column
+        Source summary followed by detector and contamination plots.
+    """
+
+    tools = ['pan', 'reset', 'box_zoom', 'wheel_zoom', 'save']
+    scene = result['target'] + result['contaminants']
+    intersecting = result.get('intersecting_sources', [])
+    detector = figure(
+        title=(f"MIRI LRS detector scene, V3PA={result['pa']} "
+               f"({len(intersecting)} extraction-overlapping sources)"),
+        width=350, height=650, tools=tools, match_aspect=True,
+        x_axis_label='MIRI/IP SCI X pixel', y_axis_label='MIRI/IP SCI Y pixel')
+    high = max(float(np.nanmax(scene)), 1.0)
+    detector.image(
+        image=[scene], x=0, y=0, dw=scene.shape[1], dh=scene.shape[0],
+        color_mapper=LogColorMapper(palette='Viridis256', low=1, high=high))
+    detector.image(
+        image=[result['extraction_mask']], x=0, y=0,
+        dw=scene.shape[1], dh=scene.shape[0],
+        color_mapper=LinearColorMapper(
+            palette=['white', 'orange'], low=0, high=1),
+        alpha=0.12)
+
+    valid = result['valid_wavelength']
+    spectrum = figure(
+        title='Contamination in the Pandeia extraction aperture', width=550,
+        height=300, tools=tools, x_axis_label='Wavelength (micron)',
+        y_axis_label='Contaminant / total pixel fraction')
+    spectrum.line(
+        result['wavelength'][valid], result['contamination'][valid],
+        line_width=2)
+    spectrum.y_range = Range1d(0, 1)
+    if intersecting:
+        source_items = ''.join(
+            f'<li>{escape(source["name"])}: detector-array offset '
+            f'(column={source["x_shift"]}, row={source["y_shift"]}), '
+            f'relative G flux={source["fluxscale"]:.4g}</li>'
+            for source in intersecting)
+        source_text = (
+            '<b>Sources whose dispersed traces enter the extraction mask:</b>'
+            f'<ul>{source_items}</ul>')
+    else:
+        source_text = (
+            '<b>No catalog-source traces enter the extraction mask at this '
+            'V3PA.</b>')
+    return column(Div(text=source_text), gridplot([[detector, spectrum]]))
 
 
 def nirissContam(cube, paRange=[0, 360], lam_file=LAM_FILE):

--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -41,9 +41,10 @@ import regions
 from ..utils import get_env_variables, check_for_data, add_array_at_position, replace_NaNs, get_target_data, get_canonical_name
 from ..pkgdata import resource_filename
 from .new_vis_plot import build_visibility_plot, get_exoplanet_positions
-from .precompute import save_exoplanet_data
 from . import contamination_figure as cf
+from . import miri_lrs
 from .gaia_tap import GaiaFailoverTAP
+from .precompute import save_exoplanet_data
 
 log_file = 'contam_tool.log'
 logging.basicConfig(
@@ -129,13 +130,27 @@ APERTURES = {'NIS_SOSSFULL': {'inst': 'NIRISS', 'full': 'NIS_SOSSFULL', 'scale':
              'NRCA5_GRISM256_F322W2': {'inst': 'NIRCam', 'full': 'NRCA5_FULL', 'scale': 0.063, 'rad': 2.5, 'lam': [2.413, 4.083], 'trim': [0, 1, 0, 1]},
              'NRCA5_GRISM256_F356W': {'inst': 'NIRCam', 'full': 'NRCA5_FULL', 'scale': 0.063, 'rad': 2.5, 'lam': [3.100, 4.041], 'trim': [0, 1, 0, 1]},
              'NRCA5_GRISM256_F444W': {'inst': 'NIRCam', 'full': 'NRCA5_FULL', 'scale': 0.063, 'rad': 2.5, 'lam': [3.835, 5.084], 'trim': [0, 1, 1250, 1]},
-             'MIRIM_SLITLESSPRISM': {'inst': 'MIRI', 'full': 'MIRIM_FULL', 'scale': 0.11, 'rad': 2.0, 'lam': [5, 12], 'trim': [6, 5, 0, 1]}}
+             'MIRIM_SLITLESSPRISM': {'inst': 'MIRI', 'full': 'MIRIM_FULL', 'scale': 0.11, 'rad': 2.0, 'lam': [5, 12], 'trim': [6, 5, 0, 1]},
+             'MIRIM_SLITLESSPRISM_IP': {
+                 'inst': 'MIRI', 'full': 'MIRIM_FULL', 'scale': 0.11,
+                 'source_search_radius_arcsec':
+                     miri_lrs.SOURCE_SEARCH_RADIUS_ARCSEC,
+                 'shape': miri_lrs.SHAPE,
+                 'dispersion_axis': miri_lrs.DISPERSION_AXIS,
+                 'cross_dispersion_axis': miri_lrs.CROSS_DISPERSION_AXIS,
+                 'trace_path': 'exoctk_contam/traces/MIRIM_SLITLESSPRISM_IP',
+                 'trace_reference_pixel': (290, 34),
+                 'science_bounds': ((0, 384), (0, 68)),
+                 'wavelength_source': 'trace_asset:WAVELENGTH',
+                 'extraction_mask_source': 'trace_asset:EXTRACTION_MASK',
+             }}
 
 WEB_CONTAMINATION_APERTURES = frozenset({
     'NIS_SUBSTRIP96',
     'NIS_SUBSTRIP256',
     'NRCA5_41STRIPE1_DHS_F322W2',
     'NRCA5_41STRIPE1_DHS_F444W',
+    'MIRIM_SLITLESSPRISM_IP',
 })
 
 # Require a majority probability before rendering a source as extended.
@@ -146,6 +161,72 @@ def contamination_supported(aperture):
     """Return whether the contamination web interface supports an aperture."""
 
     return aperture in WEB_CONTAMINATION_APERTURES
+
+
+def source_query_width(aperture):
+    """Return the Gaia query width needed to cover an aperture's sources.
+
+    Parameters
+    ----------
+    aperture : str
+        Supported contamination aperture name.
+
+    Returns
+    -------
+    astropy.units.Quantity
+        Side length of the square Gaia query region.  Its circumscribed circle
+        covers the mode's source-search radius.
+    """
+
+    if aperture == miri_lrs.APERTURE:
+        radius = APERTURES[aperture]['source_search_radius_arcsec']
+        # GaiaFailoverTAP circumscribes the requested square, so a square with
+        # side sqrt(2)*radius produces exactly the desired circular radius.
+        return np.sqrt(2.) * radius * u.arcsec
+    return 7.5 * u.arcmin
+
+
+def calculation_v3pas(aperture, observable_pas):
+    """Choose the V3 position angles at which contamination is calculated.
+
+    Parameters
+    ----------
+    aperture : str
+        Supported contamination aperture name.
+    observable_pas : array-like
+        V3 position angles observable in the requested epoch.
+
+    Returns
+    -------
+    numpy.ndarray
+        All integer angles from 0 through 359 for MIRI LRS, or the supplied
+        observable angles for other modes.
+    """
+
+    if aperture == miri_lrs.APERTURE:
+        return np.arange(360)
+    return np.asarray(observable_pas)
+
+
+def unobservable_v3pas(pa_results):
+    """Derive year-specific inaccessible V3 position angles.
+
+    Parameters
+    ----------
+    pa_results : sequence of int or miri_lrs.PositionAngleResults
+        Successfully calculated angles, optionally with explicit inaccessible
+        angle metadata.
+
+    Returns
+    -------
+    list of int
+        V3 position angles to shade as not observable.
+    """
+
+    if isinstance(pa_results, miri_lrs.PositionAngleResults):
+        return list(pa_results.inaccessible)
+    return [pa for pa in np.arange(360) if pa not in pa_results]
+
 
 DHS_STRIPES = {'NRCA5_41STRIPE1_DHS_F322W2': {'DHS5': {'x0': 2196, 'x1': 3324, 'y0': 2665, 'y1': 2671},
                                               'DHS4': {'x0': 2196, 'x1': 3324, 'y0': 2552, 'y1': 2558},
@@ -769,7 +850,8 @@ def classify_source(row):
     return stype
 
 
-def fraction_contaminated(aperture, targframes, starcube):
+def fraction_contaminated(aperture, targframes, starcube, trace_masks=None,
+                          collapse_axis=None):
     """
     Calculate the fraction of contamination per spectral trace
 
@@ -778,21 +860,37 @@ def fraction_contaminated(aperture, targframes, starcube):
     aperture: str
         The name of the aperture
     targframes: np.ndarray
-        The list of target traces
+        The target simulation frame(s)
     starcube: np.ndarray
-        The 2D or 3D contamination frame(s)
+        The simulation data cube
+    trace_masks : sequence of numpy.ndarray or numpy.ndarray, optional
+        Extraction mask for each target trace.  When omitted, masks are loaded
+        for ``aperture``.
+    collapse_axis : int, optional
+        Detector-image axis to average over.  The mode-specific default is the
+        cross-dispersion axis.
 
     Returns
     -------
     list
-        The 1D fractional contamination per trace
+        The list of fractional contamination arrays
     """
     # Check for 2D
     if starcube.ndim == 2:
         starcube = starcube[None, :, :]
 
-    # Get the trace masks
-    trace_masks = NIRCam_DHS_trace_mask(aperture) if 'NRCA5' in aperture else NIRISS_SOSS_trace_mask(aperture)
+    if trace_masks is None:
+        if aperture == miri_lrs.APERTURE:
+            trace_masks = miri_lrs.load_reference_trace().extraction_mask
+        elif 'NRCA5' in aperture:
+            trace_masks = NIRCam_DHS_trace_mask(aperture)
+        else:
+            trace_masks = NIRISS_SOSS_trace_mask(aperture)
+    if np.asarray(trace_masks).ndim == 2:
+        trace_masks = [trace_masks]
+    if collapse_axis is None:
+        collapse_axis = (miri_lrs.CROSS_DISPERSION_AXIS
+                         if aperture == miri_lrs.APERTURE else 0)
 
     # Adding frames together
     simframes = [tframe + starcube for tframe in targframes]
@@ -805,18 +903,20 @@ def fraction_contaminated(aperture, targframes, starcube):
     pctlines = []
     for i, (pframe, mask) in enumerate(zip(pctframes, trace_masks)):
         masked = np.where(mask > 0, pframe * mask, np.nan)
-        # Keep empty spectral channels as NaN, but avoid NumPy's repeated
-        # ``Mean of empty slice`` warnings for the expected empty channels.
+        # pframe always has a leading PA/cube axis, so detector axis N is
+        # cube axis N+1. Existing SOSS/DHS detector Y remains cube axis 1.
+        # Explicitly retain NaN for completely empty spectral channels without
+        # emitting NumPy's ``Mean of empty slice`` warning for every PA.
+        reduction_axis = collapse_axis + 1
         valid = ~np.isnan(masked)
-        numerator = np.nansum(masked, axis=1)
-        denominator = np.sum(valid, axis=1)
+        numerator = np.nansum(masked, axis=reduction_axis)
+        denominator = np.sum(valid, axis=reduction_axis)
         mean_line = np.divide(
             numerator, denominator,
             out=np.full(np.shape(numerator), np.nan, dtype=float),
             where=denominator > 0,
         )
         pctlines.append(mean_line)
-
     return pctlines
 
 
@@ -918,6 +1018,12 @@ def calc_v3pa(V3PA, stars, aperture, data=None, tilt=0, plot=False, POM=False):
         rows, cols = full.corners('det')
         aperture.minrow, aperture.maxrow = rows.min(), rows.max()
         aperture.mincol, aperture.maxcol = cols.min(), cols.max()
+
+    if aperture.AperName == miri_lrs.APERTURE and plot:
+        result = miri_lrs.calc_v3pa(V3PA, stars, aperture)
+        return result, cf.miri_single_pa_plot(result)
+    if aperture.AperName == miri_lrs.APERTURE:
+        return miri_lrs.calc_v3pa(V3PA, stars, aperture)
 
     # Convert the renderer's V3PA to the aperture PA required by SIAF.
     APA = aperture_pa_from_v3pa(V3PA, aperture)
@@ -1254,7 +1360,12 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None, binComp=No
     # Grab data from DB if precomputed
     if precomputed:
         targframes, starcube, attrs = fetch_contam_results(targname, target_db)
-        goodPA_list = attrs["goodPA_list"]
+        if aperture == miri_lrs.APERTURE:
+            goodPA_list = miri_lrs.PositionAngleResults(
+                successful=attrs['goodPA_list'],
+                inaccessible=attrs.get('inaccessiblePA_list', []))
+        else:
+            goodPA_list = attrs["goodPA_list"]
         logging.info(f'Using precomputed data for {targname} from {target_db}.')
 
     # Otherwise calculate it now
@@ -1283,7 +1394,9 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None, binComp=No
         update_task(task, "RUNNING SOURCE QUERY")
         if target_date is None:
             target_date = Time.now()
-        stars = find_sources(ra, dec, target_date=target_date)
+        stars = find_sources(
+            ra, dec, width=source_query_width(aperture),
+            target_date=target_date)
 
         # Add stars manually
         if isinstance(binComp, dict):
@@ -1293,15 +1406,24 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None, binComp=No
         ra_hms, dec_dms = re.sub('[a-z]', ':', targetcrd.to_string('hmsdms')).split(' ')
         goodPAs = get_exoplanet_positions(ra_hms, dec_dms, in_FOR=True)
 
-        # Calculate contamination at V3 PAs. The GTVT instrument columns are
-        # aperture PAs and would rotate a source field a second time here.
-        goodPA_list, good_group_bounds, goodPA_ints = observable_v3pa_ranges(
-            goodPAs)
+        # Contamination geometry is evaluated in V3PA. Instrument columns in
+        # GTVT are already rotated aperture PAs and must not be converted twice.
+        observable_pa_list, good_group_bounds, goodPA_ints = (
+            observable_v3pa_ranges(goodPAs))
 
-        log_checkpoint(f'Found {len(goodPA_ints)}/360 visible position angles to check')
+        # MIRI/LRS is inexpensive enough to evaluate every orientation. Keep
+        # the year-specific visibility list separately for plot shading.
+        calculation_pa_list = calculation_v3pas(
+            aperture, observable_pa_list)
+
+        log_checkpoint(
+            f'Found {len(goodPA_ints)}/360 visible position angles')
 
         # Time it
-        logging.info('Calculating target contamination from {} neighboring sources in position angle ranges {}...'.format(len(stars), good_group_bounds))
+        logging.info(
+            'Calculating target contamination from %d neighboring sources '
+            'at %d position angles; observable ranges are %s...',
+            len(stars), len(calculation_pa_list), good_group_bounds)
 
         # Calculate contamination of all stars at each PA
         # -----------------------------------------------
@@ -1311,11 +1433,23 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None, binComp=No
         # Or to take arms against a sea of troubles,
         # And by multiprocessing end them?
         results = []
-        for i, pa in enumerate(goodPA_list):
-            update_task(task, f"CALCULATING PA {i+1} OF {len(goodPA_list)}")
-            logging.info(f"Calculating PA {i+1} of {len(goodPA_list)}")
+        for i, pa in enumerate(calculation_pa_list):
+            update_task(
+                task, f"CALCULATING PA {i+1} OF {len(calculation_pa_list)}")
+            logging.info(
+                f"Calculating PA {i+1} of {len(calculation_pa_list)}")
             result = calc_v3pa(pa, stars=stars, aperture=aper, plot=False)
             results.append(result)
+
+        if aperture == miri_lrs.APERTURE:
+            observable = set(map(int, observable_pa_list))
+            successful = [int(result['pa']) for result in results]
+            goodPA_list = miri_lrs.PositionAngleResults(
+                successful=successful,
+                inaccessible=(pa for pa in range(360)
+                              if pa not in observable))
+        else:
+            goodPA_list = observable_pa_list
 
         # We only need one target frame frames
         targframes = [np.asarray(trace) for trace in results[0]['target_traces']]
@@ -1329,10 +1463,9 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None, binComp=No
 
         if (targname is not None) and (target_db is not None):
             logging.info(f"Saving {targname} to cache {target_db}")
-            # Save entry in the cache
             save_exoplanet_data(
-                target_db, targname, aperture, ra, dec, targframes, starcube, goodPA_list
-            )
+                target_db, targname, aperture, ra, dec, targframes, starcube,
+                goodPA_list=goodPA_list)
 
         # We don't need this anymore
         del results
@@ -1344,11 +1477,20 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None, binComp=No
 
         logging.info("Doing a plot here")
 
-        # Get bad PA list from missing angles between 0 and 360
-        badPAs = [j for j in np.arange(0, 360) if j not in goodPA_list]
+        # MIRI calculates inaccessible orientations too, so its visibility
+        # shading is explicit rather than inferred from missing cube planes.
+        badPAs = unobservable_v3pas(goodPA_list)
+
+        if aperture == miri_lrs.APERTURE:
+            pctlines = fraction_contaminated(aperture, targframes, starcube)
+            asset = miri_lrs.load_reference_trace()
+            contam_plot = cf.contam_slider_plot(
+                pctlines, badPAs, wavelength=asset.wavelength,
+                trace_names=['MIRI LRS'],
+                contamination_labels=['Spectrum'], y_max=0.1)
 
         # Make slider contam plot
-        if slider:
+        elif slider:
             pctlines = fraction_contaminated(aperture, targframes, starcube)
             contam_plot = cf.contam_slider_plot(
                 pctlines, badPAs, instrument=aperture)
@@ -1394,6 +1536,9 @@ def fetch_contam_results(exoplanet_name, db_filename):
             contamination[plane_index] = stored
 
         attrs = dict(grp.attrs)
+        for key in ('wavelength', 'valid_wavelength', 'extraction_mask'):
+            if key in grp:
+                attrs[key] = grp[key][:]
 
     return target_trace, contamination, attrs
 

--- a/exoctk/contam_visibility/make_miri_lrs_traces.py
+++ b/exoctk/contam_visibility/make_miri_lrs_traces.py
@@ -1,0 +1,608 @@
+#! /usr/bin/env python
+
+"""Generate Pandeia trace assets for MIRI/LRS contamination calculations."""
+
+import argparse
+import copy
+from contextlib import contextmanager
+import json
+import os
+import re
+import subprocess
+from unittest.mock import patch
+
+from astropy.io import fits
+import numpy as np
+
+from . import miri_lrs
+
+
+def pandeia_provenance(require_miri=True):
+    """Validate and report the active Pandeia data provenance.
+
+    Parameters
+    ----------
+    require_miri : bool, optional
+        Require the Pandeia engine and reference data versions used to build
+        the MIRI/IP trace assets.
+
+    Returns
+    -------
+    dict
+        Engine, source-revision, reference-data, and PSF-library versions.
+
+    Raises
+    ------
+    EnvironmentError
+        If Pandeia reference data or its PSF library is not configured.
+    RuntimeError
+        If ``require_miri`` is true and the active engine or reference data
+        does not match the required MIRI/IP generation version.
+    """
+
+    import pandeia.engine
+    from pandeia.engine import config
+
+    module_path = os.path.realpath(pandeia.engine.__file__)
+    refdata = config.default_refdata()
+    psfs = config.default_psfs()
+    if not refdata or not psfs:
+        raise EnvironmentError('Set pandeia_refdata and PSF_DIR before generation')
+    with open(os.path.join(refdata, 'VERSION_DATA')) as handle:
+        data_version = handle.readline().strip()
+    with open(os.path.join(psfs, 'VERSION_PSF')) as handle:
+        psf_version = handle.readline().strip()
+
+    # Editable/source injection over an older environment can leave stale
+    # importlib metadata.  The setup.py beside the imported source is the
+    # authoritative RC declaration and both values are reported.
+    setup_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(module_path))), 'setup.py')
+    declared_version = None
+    source_revision = None
+    if os.path.isfile(setup_path):
+        with open(setup_path) as handle:
+            match = re.search(r'version=["\']([^"\']+)', handle.read())
+        declared_version = match.group(1) if match else None
+        try:
+            source_revision = subprocess.check_output(
+                ['git', '-C', os.path.dirname(setup_path), 'describe',
+                 '--tags', '--always', '--dirty'], text=True).strip()
+        except (OSError, subprocess.CalledProcessError):
+            pass
+
+    provenance = {
+        'engine_declared_version': declared_version or pandeia.engine.__version__,
+        'engine_metadata_version': pandeia.engine.__version__,
+        'engine_source_revision': source_revision,
+        'reference_data_version': data_version,
+        'psf_version': psf_version,
+    }
+    print(f'Pandeia module:  {module_path}')
+    print(f'Engine declared: {provenance["engine_declared_version"]}')
+    print(f'Engine metadata: {provenance["engine_metadata_version"]}')
+    print(f'Engine revision: {source_revision or "unavailable"}')
+    print(f'Reference data: {os.path.realpath(refdata)} ({data_version})')
+    print(f'PSF library:    {os.path.realpath(psfs)} ({psf_version})')
+
+    if require_miri and provenance['engine_declared_version'] != '2026.7':
+        raise RuntimeError('MIRI/IP assets require Pandeia engine 2026.7')
+    if require_miri and data_version != '2026.7':
+        raise RuntimeError('MIRI/IP assets require Pandeia refdata 2026.7')
+    return provenance
+
+
+def validate_miri_ip_calculation():
+    """Run a small MIRI/IP calculation to verify Pandeia compatibility.
+
+    Returns
+    -------
+    provenance : dict
+        Version information returned by :func:`pandeia_provenance`.
+    report : dict
+        Pandeia calculation report for the validation scene.
+
+    Raises
+    ------
+    RuntimeError
+        If Pandeia reports compatibility warnings or its required versions do
+        not match the asset-generation environment.
+    """
+
+    from pandeia.engine.calc_utils import build_default_calc
+    from pandeia.engine.perform_calculation import perform_calculation
+
+    provenance = pandeia_provenance()
+    calculation = build_default_calc('jwst', 'miri', 'lrsslitless')
+    calculation['configuration']['detector']['subarray'] = 'slitlessprism_ip'
+    calculation['strategy']['background_subtraction'] = False
+    report = perform_calculation(calculation, webapp=False)
+    if report.get('warnings'):
+        raise RuntimeError(f'MIRI/IP compatibility warnings: {report["warnings"]}')
+    shape = np.asarray(report['2d']['detector']).shape
+    wave = np.asarray(report['1d']['wave_pix'])
+    print('MIRI configuration: lrsslitless / slitlessprism_ip available')
+    print(f'MIRI calculation:   compatible; grid={shape}, wavelengths={wave.size}')
+    print(f'Extraction aperture: {report["scalar"]["aperture_size"]} arcsec; '
+          f'{report["scalar"]["extraction_area"]} pixels')
+    return provenance, report
+
+
+def _scene(teff, norm_mag):
+    """Build a point-source scene normalized in Gaia G.
+
+    Parameters
+    ----------
+    teff : int or float
+        Phoenix effective temperature in kelvin.
+    norm_mag : float
+        Vega magnitude in the Gaia G band.
+
+    Returns
+    -------
+    dict
+        Pandeia scene-source configuration.
+    """
+    return {
+        'position': {'x_offset': 0., 'y_offset': 0., 'orientation': 0.},
+        'shape': {'geometry': 'point'},
+        'spectrum': {
+            'name': 'Phoenix Spectrum',
+            'normalization': {
+                'type': 'photsys', 'bandpass': 'gaia,g',
+                'norm_flux': norm_mag, 'norm_fluxunit': 'vegamag'},
+            'sed': {'sed_type': 'phoenix', 'teff': int(teff), 'log_g': 5.0,
+                    'metallicity': 0.0},
+        },
+    }
+
+
+def _miri_product(report, source_detector, aperture_size,
+                  calibrated_wave=None):
+    """Map Pandeia's expanded slitless grid into the 384x68 IP SCI frame.
+
+    ``report['2d']['detector']`` contains a random noise realization and must
+    not be used as a deterministic trace template.  ``source_detector`` is
+    Pandeia's noiseless source-rate plane, already flipped into its displayed
+    P750L orientation.  Register its central IP crop with the wavelength grid
+    and retain the expanded rows on both sides so shifted-source PSF wings are
+    cropped only after translation.
+
+    Parameters
+    ----------
+    report : dict
+        Pandeia report containing its one-dimensional wavelength grid and
+        scalar extraction metadata.
+    source_detector : numpy.ndarray
+        Expanded, noiseless Pandeia source-rate plane in displayed P750L
+        orientation.
+    aperture_size : float
+        Extraction-aperture size in arcseconds.
+    calibrated_wave : array-like, optional
+        Wavelength samples to register on the native IP subarray.  By default,
+        all projected Pandeia wavelength samples are used.
+
+    Returns
+    -------
+    trace : numpy.ndarray
+        Source-rate image on the native MIRI/IP subarray.
+    wavelength : numpy.ndarray
+        Wavelength associated with each native detector row.
+    valid : numpy.ndarray
+        Boolean mask selecting calibrated wavelength rows.
+    mask : numpy.ndarray
+        Target extraction mask.
+    blue_extension, red_extension : numpy.ndarray
+        Source-rate rows lying beyond the native detector boundaries.
+    registration : dict
+        Metadata describing wavelength and detector registration.
+
+    Raises
+    ------
+    RuntimeError
+        If the Pandeia product is invalid or cannot be registered on the
+        native MIRI/IP subarray.
+    """
+
+    # Validate the deterministic source-rate plane before using it as a
+    # reusable trace template.  Tiny negative values from numerical noise are
+    # harmless, but appreciably negative source rates indicate a bad product.
+    detector = np.asarray(source_detector, dtype=float)
+    if detector.ndim != 2 or not np.all(np.isfinite(detector)):
+        raise RuntimeError('Invalid Pandeia noiseless source-rate plane')
+    negative_tolerance = 1.e-12 * max(float(detector.max()), 1.)
+    if detector.min() < -negative_tolerance:
+        raise RuntimeError(
+            'Pandeia noiseless source-rate plane is negative: '
+            f'min={detector.min():.6g}')
+    detector = np.maximum(detector, 0.)
+    # The Pandeia grid may include extrapolated red-end samples, while
+    # calibrated_wave can select a shorter calibrated subset.  Keep both
+    # lengths because they determine different parts of the registration.
+    projected_wave = np.asarray(report['1d']['wave_pix'], dtype=float)
+    wave = (projected_wave if calibrated_wave is None else
+            np.asarray(calibrated_wave, dtype=float))
+    n_projected = len(projected_wave)
+    n_wave = len(wave)
+    if n_wave > n_projected:
+        raise RuntimeError('Calibrated wavelength grid exceeds Pandeia grid')
+    # Align the wavelength-bearing rows with the native IP subarray, then
+    # align the narrow Pandeia detector plane with the SIAF reference column.
+    pandeia_row0 = (detector.shape[0] - n_projected) // 2 + 1
+    output_row0 = (miri_lrs.SHAPE[0] - n_wave) // 2
+    detector_row0 = pandeia_row0 - output_row0
+    reference_x = 34  # zero-based form of SIAF XSciRef=34.5
+    pandeia_x = detector.shape[1] // 2
+    output_x0 = reference_x - pandeia_x
+
+    # Split the expanded Pandeia plane into the on-detector template and the
+    # two off-detector extensions.  The extensions can later enter the native
+    # frame when a neighboring source is translated along the dispersion axis.
+    detector_row1 = detector_row0 + miri_lrs.SHAPE[0]
+    if detector_row0 < 0 or detector_row1 > detector.shape[0]:
+        raise RuntimeError('Pandeia detector scene cannot cover the MIRI/IP subarray')
+    trace = np.zeros(miri_lrs.SHAPE, dtype=float)
+    trace[:, output_x0:output_x0 + detector.shape[1]] = detector[
+        detector_row0:detector_row1]
+    blue_extension = np.zeros((detector_row0, miri_lrs.SHAPE[1]), dtype=float)
+    blue_extension[:, output_x0:output_x0 + detector.shape[1]] = detector[
+        :detector_row0]
+    red_extension = np.zeros(
+        (detector.shape[0] - detector_row1, miri_lrs.SHAPE[1]), dtype=float)
+    red_extension[:, output_x0:output_x0 + detector.shape[1]] = detector[
+        detector_row1:]
+    # Register wavelengths only on rows covered by the selected grid; NaNs
+    # distinguish the remaining detector rows from calibrated spectral data.
+    wavelength = np.full(miri_lrs.SHAPE[0], np.nan)
+    # Pandeia reports wave_pix from red to blue for this mode, while detector
+    # row index increases from the blue end to the red end.  Its extracted 1-D
+    # flux therefore matches the detector rows only when wave_pix is reversed.
+    wavelength[output_row0:output_row0 + n_wave] = wave[::-1]
+    valid = np.isfinite(wavelength)
+
+    # Pandeia SpecApPhot reports 12 pixels for its 1.32 arcsec strip.  Preserve
+    # that definition and center it on the SIAF target reference column.
+    width = int(round(float(report['scalar']['extraction_area'])))
+    if not np.isclose(width, report['scalar']['extraction_area']):
+        raise RuntimeError('Non-integral MIRI extraction aperture needs weighted-mask support')
+    mask = np.zeros(miri_lrs.SHAPE, dtype=float)
+    x0 = reference_x - width // 2 + 1
+    mask[valid, x0:x0 + width] = 1.0
+    # Store enough registration metadata to audit how the Pandeia product was
+    # cropped and to place its off-detector extensions during later rendering.
+    registration = {
+        'pandeia_wavelength_row0': pandeia_row0,
+        'pandeia_projected_wavelength_rows': int(n_projected),
+        'pandeia_calibrated_wavelength_rows': int(n_wave),
+        'pandeia_detector_row0': detector_row0,
+        'pandeia_detector_product': 'noiseless_source_rate',
+        'pandeia_expanded_detector_rows': int(detector.shape[0]),
+        'ip_wavelength_row0': output_row0,
+        'ip_cross_dispersion_col0': output_x0,
+        'blue_extension_y0': int(-detector_row0),
+        'blue_extension_rows': int(blue_extension.shape[0]),
+        'red_extension_y0': int(miri_lrs.SHAPE[0]),
+        'red_extension_rows': int(red_extension.shape[0]),
+        'extension_method': 'pandeia_noiseless_source_rate',
+        'extraction_width_pixels': width,
+        'extraction_aperture_arcsec': aperture_size,
+        'registration_status': 'experimental_requires_manual_validation',
+    }
+    return (trace, wavelength, valid, mask, blue_extension, red_extension,
+            registration)
+
+
+def _extended_miri_wave_pix(wave_pix, zero_wavelength, fit_rows=32):
+    """Extrapolate the P750L pixel grid through its terminal response zero.
+
+    Pandeia's MIRI/IP dispersion grid currently stops at about 13.86 microns,
+    although the P750L response remains nonzero for several more detector
+    pixels.  Continue the local wavelength solution by detector pixel so the
+    engine can project those wavelengths instead of leaving only the PSF wing
+    of its final calibrated sample.
+
+    Parameters
+    ----------
+    wave_pix : array-like
+        Native, monotonically increasing wavelength-per-pixel grid in microns.
+    zero_wavelength : float
+        Wavelength of the first terminal zero in the P750L response table.
+    fit_rows : int, optional
+        Number of red-end native pixels used for the local quadratic fit.
+
+    Returns
+    -------
+    numpy.ndarray
+        Native wavelength grid extended exactly to ``zero_wavelength``.
+
+    Raises
+    ------
+    RuntimeError
+        If the input grid is invalid, extrapolation ceases to increase, or the
+        response zero cannot be reached within the safety limit.
+    """
+
+    wave = np.asarray(wave_pix, dtype=float)
+    if (wave.ndim != 1 or len(wave) < fit_rows or
+            not np.all(np.isfinite(wave)) or not np.all(np.diff(wave) > 0.)):
+        raise RuntimeError('Invalid P750L wavelength/pixel grid')
+    if zero_wavelength <= wave[-1]:
+        raise RuntimeError('P750L response zero is not redward of pixel grid')
+
+    pixels = np.arange(len(wave), dtype=float)
+    coefficients = np.polyfit(
+        pixels[-fit_rows:], wave[-fit_rows:], 2)
+    extended = wave.tolist()
+    for pixel in range(len(wave), len(wave) + 128):
+        value = float(np.polyval(coefficients, pixel))
+        if value <= extended[-1]:
+            raise RuntimeError('P750L wavelength extrapolation is not increasing')
+        extended.append(min(value, float(zero_wavelength)))
+        if extended[-1] == float(zero_wavelength):
+            break
+    else:
+        raise RuntimeError('Could not reach P750L response zero in 128 pixels')
+    return np.asarray(extended)
+
+
+@contextmanager
+def _extended_miri_pandeia_grid(zero_wavelength):
+    """Temporarily extend the MIRI/IP pixel grid to its response-table zero.
+
+    The engine limits MIRI/IP to the end of its calibrated dispersion table,
+    while the P750L response table remains nonzero slightly farther redward.
+    Extend only this mode's wavelength-to-pixel relation and use its local
+    pixel spacing as the added dispersion. Pandeia continues to evaluate its
+    unmodified response table, SED, remaining throughput terms, quantum yield,
+    and PSF projection at the added wavelengths.
+
+    Parameters
+    ----------
+    zero_wavelength : float
+        Wavelength of the terminal P750L response zero, in microns.
+
+    Yields
+    ------
+    None
+        Control while MIRI LRS wavelength-grid methods are temporarily
+        patched.  Original methods are restored on context exit.
+    """
+
+    from pandeia.engine.jwst import MIRI
+
+    original_wave_pix = MIRI.get_wave_pix
+    original_wave_range = MIRI.get_wave_range
+    original_dispersion = MIRI.get_dispersion
+
+    def get_dispersion(instance, wave):
+        """Evaluate native or extrapolated dispersion at input wavelengths.
+
+        Parameters
+        ----------
+        instance : pandeia.engine.jwst.MIRI
+            Instrument instance being evaluated.
+        wave : array-like
+            Wavelengths in microns.
+
+        Returns
+        -------
+        numpy.ndarray
+            Dispersion in microns per detector pixel.
+        """
+        if instance.mode != 'lrsslitless':
+            return original_dispersion(instance, wave)
+        native = np.asarray(original_wave_pix(instance), dtype=float)
+        values = np.asarray(wave, dtype=float)
+        red = values > native[-1]
+        # Do not ask the native dispersion interpolator to evaluate outside
+        # its calibrated wavelength grid. Its value there is replaced below
+        # by the local pixel spacing of the extrapolated wavelength solution.
+        dispersion = np.empty_like(values, dtype=float)
+        if np.any(~red):
+            dispersion[~red] = original_dispersion(instance, values[~red])
+        if np.any(red):
+            extended = _extended_miri_wave_pix(native, zero_wavelength)
+            pixel_width = np.gradient(extended)
+            dispersion[red] = np.interp(
+                values[red], extended, pixel_width)
+        return dispersion
+
+    with (patch.object(
+              MIRI, 'get_wave_pix',
+              lambda instance: _extended_miri_wave_pix(
+                  original_wave_pix(instance), zero_wavelength)
+              if instance.mode == 'lrsslitless'
+              else original_wave_pix(instance)),
+          patch.object(
+              MIRI, 'get_wave_range',
+              lambda instance: dict(
+                  original_wave_range(instance),
+                  wmax=float(zero_wavelength))
+              if instance.mode == 'lrsslitless'
+              else original_wave_range(instance)),
+          patch.object(MIRI, 'get_dispersion', get_dispersion)):
+        yield
+
+
+def _miri_red_response_limit(calculation):
+    """Find the P750L terminal response zero and native grid limit.
+
+    Parameters
+    ----------
+    calculation : dict
+        Pandeia calculation configuration for MIRI LRS slitless mode.
+
+    Returns
+    -------
+    dict
+        Terminal zero wavelength, native red wavelength limit, and response
+        filename.
+
+    Raises
+    ------
+    RuntimeError
+        If the response lacks a terminal zero or that zero is not redward of
+        the native wavelength grid.
+    """
+
+    from pandeia.engine.instrument_factory import InstrumentFactory
+
+    instrument = InstrumentFactory(config=calculation['configuration'])
+    key = '{}_{}'.format(
+        instrument.instrument['aperture'],
+        instrument.instrument['disperser'])
+    path = os.path.join(instrument.ref_dir, instrument.paths[key])
+    response = fits.getdata(path, 1)
+    wave = np.asarray(response['WAVELENGTH'], dtype=float)
+    throughput = np.asarray(response['THROUGHPUT'], dtype=float)
+    positive = np.flatnonzero(np.isfinite(throughput) & (throughput > 0.))
+    if not len(positive) or positive[-1] + 1 >= len(wave):
+        raise RuntimeError('P750L response has no terminal zero-throughput sample')
+    reference_zero_index = positive[-1] + 1
+    if throughput[reference_zero_index] != 0.:
+        raise RuntimeError('P750L terminal response sample is not zero')
+
+    native_red_limit = float(instrument.get_wave_range()['wmax'])
+    terminal_zero = float(wave[reference_zero_index])
+    if terminal_zero <= native_red_limit:
+        raise RuntimeError(
+            'P750L response zero is not redward of the native pixel grid')
+    return {
+        'zero': terminal_zero,
+        'native_red_limit': native_red_limit,
+        'response_file': os.path.basename(path),
+    }
+
+
+def generate_miri_ip_traces(min_teff=2800, max_teff=6000, increment=100,
+                            norm_mag=20., outdir=None):
+    """Generate ``MIRIM_SLITLESSPRISM_IP`` trace assets with Pandeia.
+
+    Parameters
+    ----------
+    min_teff, max_teff : int, optional
+        Inclusive effective-temperature range in kelvin.
+    increment : int, optional
+        Temperature spacing in kelvin.
+    norm_mag : float, optional
+        Vega magnitude used to normalize every Phoenix scene in Gaia G.
+    outdir : str or path-like, optional
+        Output directory.  By default, assets are written to
+        :func:`miri_lrs.trace_directory`.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    EnvironmentError
+        If Pandeia reference data or the ExoCTK data root is unavailable.
+    RuntimeError
+        If the Pandeia environment is incompatible, a calculation emits
+        warnings, or a detector product cannot be registered safely.
+    """
+
+    from pandeia.engine.calc_utils import build_default_calc
+    from pandeia.engine.perform_calculation import perform_calculation
+
+    provenance = pandeia_provenance()
+    output = outdir or miri_lrs.trace_directory()
+    os.makedirs(output, exist_ok=True)
+
+    base = build_default_calc('jwst', 'miri', 'lrsslitless')
+    base['configuration']['detector']['subarray'] = 'slitlessprism_ip'
+    base['strategy']['background_subtraction'] = False
+    aperture_size = base['strategy']['aperture_size']
+    red_response = _miri_red_response_limit(base)
+    red_zero = red_response['zero']
+    native_red_limit = red_response['native_red_limit']
+    with _extended_miri_pandeia_grid(red_zero):
+        for teff in np.arange(min_teff, max_teff + increment, increment):
+            calculation = copy.deepcopy(base)
+            calculation['scene'] = [_scene(teff, norm_mag)]
+            report_object = perform_calculation(
+                calculation, dict_report=False, webapp=False)
+            report = report_object.as_dict()
+            if report.get('warnings'):
+                raise RuntimeError(
+                    f'Pandeia warnings for MIRI/IP: {report["warnings"]}')
+            # Match Pandeia's public P750L display orientation without using
+            # its stochastic detector report, which adds a random noise
+            # realization. Keep the native calibrated target wavelengths;
+            # the added red rows are solely an off-detector source extension.
+            source_detector = np.asarray(
+                report_object.signal.rate, dtype=float)[::-1]
+            projected_wave = np.asarray(
+                report['1d']['wave_pix'], dtype=float)
+            calibrated_wave = projected_wave[
+                projected_wave <= native_red_limit]
+            (trace, wavelength, valid, mask, blue_extension, red_extension,
+             registration) = _miri_product(
+                report, source_detector, aperture_size,
+                calibrated_wave=calibrated_wave)
+            metadata = dict(provenance, **registration)
+            metadata.update({
+                'source_teff': int(teff),
+                'normalization_magnitude': float(norm_mag),
+                'normalization_bandpass': 'gaia,g',
+                'shape': list(miri_lrs.SHAPE), 'dispersion_axis': 0,
+                'cross_dispersion_axis': 1,
+                'wavelength_orientation': 'increasing_toward_negative_y_sci',
+                'short_wavelength_foldover': 'none_in_pandeia_wave_pix',
+                'p750l_response_file': red_response['response_file'],
+                'p750l_native_red_limit_micron': float(native_red_limit),
+                'p750l_terminal_zero_wavelength_micron': red_zero,
+                'red_extension_method':
+                    'pandeia_extended_pixel_grid_reference_response',
+            })
+            primary = fits.PrimaryHDU()
+            primary.header['APERTURE'] = miri_lrs.APERTURE
+            primary.header['REFYPIX'] = 290
+            primary.header['REFXPIX'] = 34
+            primary.header['METAJSON'] = json.dumps(
+                metadata, separators=(',', ':'))
+            hdul = fits.HDUList([
+                primary,
+                fits.ImageHDU(trace.astype('float32'), name='TRACE'),
+                fits.ImageHDU(
+                    wavelength.astype('float64'), name='WAVELENGTH'),
+                fits.ImageHDU(
+                    mask.astype('float32'), name='EXTRACTION_MASK'),
+                fits.ImageHDU(
+                    valid.astype('uint8'), name='VALID_WAVELENGTH'),
+                fits.ImageHDU(blue_extension.astype('float32'),
+                              name='BLUE_EXTENSION'),
+                fits.ImageHDU(red_extension.astype('float32'),
+                              name='RED_EXTENSION'),
+            ])
+            path = os.path.join(
+                output, f'{miri_lrs.APERTURE}_{int(teff)}.fits')
+            hdul.writeto(path, overwrite=True)
+            print(f'Saved {path}')
+
+
+def main():
+    """Run the MIRI/IP trace-generation command-line interface.
+
+    Returns
+    -------
+    None
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--validate-only', action='store_true')
+    parser.add_argument('--min-teff', type=int, default=2800)
+    parser.add_argument('--max-teff', type=int, default=6000)
+    parser.add_argument('--increment', type=int, default=100)
+    parser.add_argument('--norm-mag', type=float, default=20.)
+    parser.add_argument('--outdir')
+    args = parser.parse_args()
+    if args.validate_only:
+        validate_miri_ip_calculation()
+    else:
+        generate_miri_ip_traces(args.min_teff, args.max_teff, args.increment,
+                                args.norm_mag, args.outdir)
+
+
+if __name__ == '__main__':
+    main()

--- a/exoctk/contam_visibility/make_miri_lrs_traces.py
+++ b/exoctk/contam_visibility/make_miri_lrs_traces.py
@@ -7,24 +7,17 @@ import copy
 from contextlib import contextmanager
 import json
 import os
-import re
-import subprocess
 from unittest.mock import patch
 
 from astropy.io import fits
 import numpy as np
 
+from ..utils import pandeia_provenance
 from . import miri_lrs
 
 
-def pandeia_provenance(require_miri=True):
-    """Validate and report the active Pandeia data provenance.
-
-    Parameters
-    ----------
-    require_miri : bool, optional
-        Require the Pandeia engine and reference data versions used to build
-        the MIRI/IP trace assets.
+def _miri_pandeia_provenance():
+    """Validate Pandeia provenance for MIRI/IP trace-asset generation.
 
     Returns
     -------
@@ -33,61 +26,15 @@ def pandeia_provenance(require_miri=True):
 
     Raises
     ------
-    EnvironmentError
-        If Pandeia reference data or its PSF library is not configured.
     RuntimeError
-        If ``require_miri`` is true and the active engine or reference data
-        does not match the required MIRI/IP generation version.
+        If the active engine or reference data does not match the required
+        MIRI/IP generation version.
     """
 
-    import pandeia.engine
-    from pandeia.engine import config
-
-    module_path = os.path.realpath(pandeia.engine.__file__)
-    refdata = config.default_refdata()
-    psfs = config.default_psfs()
-    if not refdata or not psfs:
-        raise EnvironmentError('Set pandeia_refdata and PSF_DIR before generation')
-    with open(os.path.join(refdata, 'VERSION_DATA')) as handle:
-        data_version = handle.readline().strip()
-    with open(os.path.join(psfs, 'VERSION_PSF')) as handle:
-        psf_version = handle.readline().strip()
-
-    # Editable/source injection over an older environment can leave stale
-    # importlib metadata.  The setup.py beside the imported source is the
-    # authoritative RC declaration and both values are reported.
-    setup_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(module_path))), 'setup.py')
-    declared_version = None
-    source_revision = None
-    if os.path.isfile(setup_path):
-        with open(setup_path) as handle:
-            match = re.search(r'version=["\']([^"\']+)', handle.read())
-        declared_version = match.group(1) if match else None
-        try:
-            source_revision = subprocess.check_output(
-                ['git', '-C', os.path.dirname(setup_path), 'describe',
-                 '--tags', '--always', '--dirty'], text=True).strip()
-        except (OSError, subprocess.CalledProcessError):
-            pass
-
-    provenance = {
-        'engine_declared_version': declared_version or pandeia.engine.__version__,
-        'engine_metadata_version': pandeia.engine.__version__,
-        'engine_source_revision': source_revision,
-        'reference_data_version': data_version,
-        'psf_version': psf_version,
-    }
-    print(f'Pandeia module:  {module_path}')
-    print(f'Engine declared: {provenance["engine_declared_version"]}')
-    print(f'Engine metadata: {provenance["engine_metadata_version"]}')
-    print(f'Engine revision: {source_revision or "unavailable"}')
-    print(f'Reference data: {os.path.realpath(refdata)} ({data_version})')
-    print(f'PSF library:    {os.path.realpath(psfs)} ({psf_version})')
-
-    if require_miri and provenance['engine_declared_version'] != '2026.7':
+    provenance = pandeia_provenance()
+    if provenance['engine_declared_version'] != '2026.7':
         raise RuntimeError('MIRI/IP assets require Pandeia engine 2026.7')
-    if require_miri and data_version != '2026.7':
+    if provenance['reference_data_version'] != '2026.7':
         raise RuntimeError('MIRI/IP assets require Pandeia refdata 2026.7')
     return provenance
 
@@ -98,7 +45,7 @@ def validate_miri_ip_calculation():
     Returns
     -------
     provenance : dict
-        Version information returned by :func:`pandeia_provenance`.
+        Validated Pandeia version information.
     report : dict
         Pandeia calculation report for the validation scene.
 
@@ -112,7 +59,7 @@ def validate_miri_ip_calculation():
     from pandeia.engine.calc_utils import build_default_calc
     from pandeia.engine.perform_calculation import perform_calculation
 
-    provenance = pandeia_provenance()
+    provenance = _miri_pandeia_provenance()
     calculation = build_default_calc('jwst', 'miri', 'lrsslitless')
     calculation['configuration']['detector']['subarray'] = 'slitlessprism_ip'
     calculation['strategy']['background_subtraction'] = False
@@ -506,7 +453,7 @@ def generate_miri_ip_traces(min_teff=2800, max_teff=6000, increment=100,
     from pandeia.engine.calc_utils import build_default_calc
     from pandeia.engine.perform_calculation import perform_calculation
 
-    provenance = pandeia_provenance()
+    provenance = _miri_pandeia_provenance()
     output = outdir or miri_lrs.trace_directory()
     os.makedirs(output, exist_ok=True)
 

--- a/exoctk/contam_visibility/miniTools.py
+++ b/exoctk/contam_visibility/miniTools.py
@@ -164,7 +164,7 @@ def contamVerify(RA, DEC, INSTRUMENT, APAlist, binComp=[], PDF='', web=False):
     apertures['NIRISS'] = ['NIS_SOSSFULL', 'NIS_SOSSFULL']
     apertures['NIRCam F444W'] = ['NRCA5_GRISM256_F444W', 'NRCA5_FULL']
     apertures['NIRCam F322W2'] = ['NRCA5_GRISM256_F322W2', 'NRCA5_FULL']
-    apertures['MIRI'] = ['MIRIM_SLITLESSPRISM', 'MIRIM_FULL']
+    apertures['MIRI'] = ['MIRIM_SLITLESSPRISM_IP', 'MIRIM_FULL']
 
     # Instantiate SIAF object
     siaf = pysiaf.Siaf(INSTRUMENT.split(' ')[0])

--- a/exoctk/contam_visibility/miri_lrs.py
+++ b/exoctk/contam_visibility/miri_lrs.py
@@ -1,0 +1,537 @@
+"""MIRI LRS slitless contamination helpers.
+
+Normal contamination calculations use precomputed Pandeia products.  Pandeia
+is intentionally imported only by :mod:`make_miri_lrs_traces`, never here.
+Arrays in this module follow Pandeia's displayed detector order:
+``(row, x_sci)``.  For MIRI/P750L, increasing array row is opposite to
+increasing ``Y_SCI``.
+"""
+
+from dataclasses import dataclass
+from functools import lru_cache
+import glob
+import json
+import os
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
+import numpy as np
+import pysiaf
+
+
+APERTURE = "MIRIM_SLITLESSPRISM_IP"
+SHAPE = (384, 68)
+DISPERSION_AXIS = 0
+CROSS_DISPERSION_AXIS = 1
+SOURCE_SEARCH_RADIUS_ARCSEC = 60.0
+TRACE_GLOB = "MIRIM_SLITLESSPRISM_IP_*.fits"
+
+
+class PositionAngleResults(list):
+    """Calculated position angles with explicit visibility bookkeeping.
+
+    Parameters
+    ----------
+    successful : iterable of int, optional
+        Position angles for which contamination was calculated successfully.
+    inaccessible : iterable of int, optional
+        Position angles that are not observable in the requested epoch.
+
+    Attributes
+    ----------
+    inaccessible : list of int
+        The inaccessible position angles.  The list contents inherited by this
+        class are the successfully calculated position angles.
+    """
+
+    def __init__(self, successful=(), inaccessible=()):
+        """Initialize calculated and inaccessible position angles.
+
+        Parameters
+        ----------
+        successful : iterable of int, optional
+            Successfully calculated position angles stored as list contents.
+        inaccessible : iterable of int, optional
+            Unobservable position angles stored in :attr:`inaccessible`.
+        """
+        super().__init__(successful)
+        self.inaccessible = list(inaccessible)
+
+
+@dataclass(frozen=True)
+class MiriTraceAsset:
+    """One target-centered trace template and its calibration products.
+
+    Attributes
+    ----------
+    trace : numpy.ndarray
+        Source-rate image on the native MIRI/IP detector subarray.
+    wavelength : numpy.ndarray
+        Wavelength associated with each dispersion-axis detector row.
+    extraction_mask : numpy.ndarray
+        Pixel weights defining the target extraction aperture.
+    valid_wavelength : numpy.ndarray
+        Boolean mask identifying rows with calibrated target wavelengths.
+    reference_pixel : tuple of int
+        Zero-based ``(row, column)`` reference pixel stored in the asset.
+    metadata : dict
+        Provenance and detector-registration metadata.
+    red_extension, blue_extension : numpy.ndarray or None
+        Off-detector source-rate tails used when a displaced source spectrum
+        moves onto the detector.
+    red_extension_y0, blue_extension_y0 : int
+        Starting detector-array row of each extension before source shifting.
+    """
+
+    trace: np.ndarray
+    wavelength: np.ndarray
+    extraction_mask: np.ndarray
+    valid_wavelength: np.ndarray
+    reference_pixel: tuple
+    metadata: dict
+    red_extension: np.ndarray | None = None
+    red_extension_y0: int = SHAPE[0]
+    blue_extension: np.ndarray | None = None
+    blue_extension_y0: int = 0
+
+
+def trace_directory(exoctk_data=None):
+    """Return the external-data directory containing MIRI/IP templates.
+
+    Parameters
+    ----------
+    exoctk_data : str or path-like, optional
+        ExoCTK data root.  When omitted, the ``EXOCTK_DATA`` environment
+        variable is used.
+
+    Returns
+    -------
+    str
+        Path to the MIRI/IP trace directory.
+
+    Raises
+    ------
+    EnvironmentError
+        If neither ``exoctk_data`` nor ``EXOCTK_DATA`` supplies a data root.
+    """
+
+    root = exoctk_data or os.environ.get("EXOCTK_DATA")
+    if not root:
+        raise EnvironmentError("EXOCTK_DATA is required to load MIRI/IP traces")
+    return os.path.join(root, "exoctk_contam", "traces", APERTURE)
+
+
+@lru_cache(maxsize=128)
+def load_trace(teff, exoctk_data=None):
+    """Load the nearest-temperature MIRI/IP trace and validate its metadata.
+
+    Parameters
+    ----------
+    teff : float
+        Requested source effective temperature in kelvin.
+    exoctk_data : str or path-like, optional
+        ExoCTK data root.  When omitted, ``EXOCTK_DATA`` is used.
+
+    Returns
+    -------
+    MiriTraceAsset
+        Cached trace asset whose tabulated temperature is closest to ``teff``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no MIRI/IP trace assets are installed.
+    ValueError
+        If the selected asset has inconsistent shapes, aperture metadata, or
+        off-detector extensions.
+    """
+
+    files = glob.glob(os.path.join(trace_directory(exoctk_data), TRACE_GLOB))
+    if not files:
+        raise FileNotFoundError(
+            f"No {APERTURE} trace assets found; run make_miri_lrs_traces.py"
+        )
+    path = min(files, key=lambda item: abs(
+        int(os.path.splitext(os.path.basename(item))[0].rsplit("_", 1)[1])
+        - teff))
+    with fits.open(path) as hdul:
+        trace = np.asarray(hdul["TRACE"].data, dtype=float)
+        wavelength = np.asarray(hdul["WAVELENGTH"].data, dtype=float).ravel()
+        mask = np.asarray(hdul["EXTRACTION_MASK"].data, dtype=float)
+        valid = np.asarray(hdul["VALID_WAVELENGTH"].data, dtype=bool).ravel()
+        red_extension = (np.asarray(hdul["RED_EXTENSION"].data, dtype=float)
+                         if "RED_EXTENSION" in hdul else None)
+        blue_extension = (np.asarray(hdul["BLUE_EXTENSION"].data, dtype=float)
+                          if "BLUE_EXTENSION" in hdul else None)
+        header = hdul[0].header
+        metadata = json.loads(header.get("METAJSON", "{}"))
+        reference = (int(header["REFYPIX"]), int(header["REFXPIX"]))
+
+    if trace.shape != SHAPE or mask.shape != SHAPE:
+        raise ValueError(f"Invalid {APERTURE} asset shape in {path}: {trace.shape}")
+    if wavelength.shape != (SHAPE[DISPERSION_AXIS],) or valid.shape != wavelength.shape:
+        raise ValueError(f"Invalid wavelength calibration shape in {path}")
+    if header.get("APERTURE") != APERTURE:
+        raise ValueError(f"Trace asset aperture mismatch in {path}")
+
+    red_y0 = int(metadata.get("red_extension_y0", SHAPE[0]))
+    blue_y0 = int(metadata.get("blue_extension_y0", 0))
+    if (red_extension is None or red_extension.ndim != 2 or
+            red_extension.shape[1] != SHAPE[1] or red_y0 != SHAPE[0]):
+        raise ValueError(f"Invalid red-wavelength extension in {path}")
+    if (blue_extension is None or blue_extension.ndim != 2 or
+            blue_extension.shape[1] != SHAPE[1] or
+            blue_y0 + blue_extension.shape[0] != 0):
+        raise ValueError(f"Invalid blue-wavelength extension in {path}")
+
+    return MiriTraceAsset(
+        trace=trace, wavelength=wavelength, extraction_mask=mask,
+        valid_wavelength=valid, reference_pixel=reference, metadata=metadata,
+        red_extension=red_extension, red_extension_y0=red_y0,
+        blue_extension=blue_extension, blue_extension_y0=blue_y0)
+
+
+def load_reference_trace(exoctk_data=None):
+    """Load the canonical asset used for shared LRS calibration products.
+
+    MIRI/LRS assets have temperature-dependent source traces but share their
+    wavelength solution, extraction mask, and generation provenance. Callers
+    that need those shared products should use this helper instead of choosing
+    an apparently scientific source temperature themselves.
+
+    Parameters
+    ----------
+    exoctk_data : str or path-like, optional
+        ExoCTK data root.  When omitted, ``EXOCTK_DATA`` is used.
+
+    Returns
+    -------
+    MiriTraceAsset
+        The designated calibration-reference trace asset.
+    """
+
+    # These products are duplicated in every temperature-dependent trace
+    # asset; the selected temperature has no scientific role here.
+    reference_temperature = 4000
+    if exoctk_data is None:
+        return load_trace(reference_temperature)
+    return load_trace(reference_temperature, exoctk_data)
+
+
+def shift_trace(trace, y_shift, x_shift, shape=SHAPE, source_y0=0,
+                source_x0=0):
+    """Translate a trace by integer detector-array offsets with clipping.
+
+    Parameters
+    ----------
+    trace : numpy.ndarray
+        Two-dimensional source image to translate.
+    y_shift, x_shift : int
+        Row and column offsets relative to the target-centered image.
+    shape : tuple of int, optional
+        ``(rows, columns)`` shape of the returned detector image.
+    source_y0, source_x0 : int, optional
+        Native row and column origin of ``trace`` relative to the detector.
+
+    Returns
+    -------
+    numpy.ndarray
+        Shifted image clipped to ``shape``.
+    """
+
+    source = np.asarray(trace)
+    output = np.zeros(shape, dtype=source.dtype)
+    y_shift = int(y_shift) + int(source_y0)
+    x_shift = int(x_shift) + int(source_x0)
+    src_y0, src_x0 = max(0, -y_shift), max(0, -x_shift)
+    dst_y0, dst_x0 = max(0, y_shift), max(0, x_shift)
+    height = min(source.shape[0] - src_y0, shape[0] - dst_y0)
+    width = min(source.shape[1] - src_x0, shape[1] - dst_x0)
+    if height > 0 and width > 0:
+        output[dst_y0:dst_y0 + height, dst_x0:dst_x0 + width] = source[
+            src_y0:src_y0 + height, src_x0:src_x0 + width
+        ]
+    return output
+
+
+def render_trace(asset, y_shift, x_shift, shape=SHAPE):
+    """Translate a trace asset and its off-detector source-rate tails.
+
+    Parameters
+    ----------
+    asset : MiriTraceAsset
+        Trace asset to render.
+    y_shift, x_shift : int
+        Row and column offsets from the target reference position.
+    shape : tuple of int, optional
+        ``(rows, columns)`` shape of the returned detector image.
+
+    Returns
+    -------
+    numpy.ndarray
+        Shifted source-rate image including any detector-crossing extensions.
+    """
+
+    rendered = shift_trace(asset.trace, y_shift, x_shift, shape=shape)
+    if asset.blue_extension is not None:
+        rendered += shift_trace(
+            asset.blue_extension, y_shift, x_shift, shape=shape,
+            source_y0=asset.blue_extension_y0)
+    if asset.red_extension is not None:
+        rendered += shift_trace(
+            asset.red_extension, y_shift, x_shift, shape=shape,
+            source_y0=asset.red_extension_y0)
+    return rendered
+
+
+def source_offsets(stars, aperture, attitude):
+    """Populate source coordinates and return rigid array offsets from target.
+
+    ``pysiaf`` SCI coordinates are one-indexed pixel-center coordinates.  Their
+    differences provide the source displacement in the aperture.  Pandeia's
+    displayed P750L detector product has increasing columns along ``+X_SCI``
+    but increasing rows along ``-Y_SCI``, so only the Y difference changes
+    sign when converted to a NumPy array shift.
+
+    Parameters
+    ----------
+    stars : astropy.table.Table
+        Sources with ``ra`` and ``dec`` columns and writable detector,
+        telescope, and science-coordinate columns.  Row zero is the target.
+    aperture : pysiaf.aperture.JwstAperture
+        MIRI/IP aperture used for coordinate transformations.
+    attitude : numpy.ndarray
+        SIAF attitude matrix for the requested V3 position angle.
+
+    Returns
+    -------
+    list of tuple of int
+        ``(row_shift, column_shift)`` for each source, beginning with ``(0, 0)``
+        for the target.
+
+    Notes
+    -----
+    Coordinate columns in ``stars`` are populated in place.
+    """
+
+    target_xdet, target_ydet = aperture.reference_point("det")
+    target_xtel, target_ytel = aperture.det_to_tel(target_xdet, target_ydet)
+    target_xsci, target_ysci = aperture.det_to_sci(target_xdet, target_ydet)
+    stars["xdet"][0], stars["ydet"][0] = target_xdet, target_ydet
+    stars["xtel"][0], stars["ytel"][0] = target_xtel, target_ytel
+    stars["xsci"][0], stars["ysci"][0] = target_xsci, target_ysci
+
+    if len(stars) == 1:
+        return [(0, 0)]
+
+    # All pysiaf transforms used here accept arrays.  Keeping the operation
+    # vectorized avoids thousands of Python/Quantity calls for crowded fields.
+    v2, v3 = pysiaf.utils.rotations.sky_to_tel(
+        attitude, np.asarray(stars["ra"][1:], dtype=float),
+        np.asarray(stars["dec"][1:], dtype=float))
+    stars["xtel"][1:] = v2.to_value(u.arcsec)
+    stars["ytel"][1:] = v3.to_value(u.arcsec)
+    stars["xdet"][1:], stars["ydet"][1:] = aperture.tel_to_det(
+        stars["xtel"][1:], stars["ytel"][1:])
+    stars["xsci"][1:], stars["ysci"][1:] = aperture.det_to_sci(
+        stars["xdet"][1:], stars["ydet"][1:])
+    y_offsets = -np.rint(stars["ysci"][1:] - target_ysci).astype(int)
+    x_offsets = np.rint(stars["xsci"][1:] - target_xsci).astype(int)
+    return [(0, 0), *zip(y_offsets.tolist(), x_offsets.tolist())]
+
+
+def nearby_source_indices(stars, radius_arcsec):
+    """Select the target and catalog sources within a sky radius.
+
+    Parameters
+    ----------
+    stars : astropy.table.Table
+        Source table whose first row is the target and which contains ``ra``
+        and ``dec`` columns in degrees.
+    radius_arcsec : float
+        Maximum angular separation from the target in arcseconds.
+
+    Returns
+    -------
+    numpy.ndarray
+        Integer row indices, always including target row zero when present.
+    """
+
+    if len(stars) == 0:
+        return np.array([], dtype=int)
+    coordinates = SkyCoord(
+        np.asarray(stars["ra"], dtype=float) * u.deg,
+        np.asarray(stars["dec"], dtype=float) * u.deg)
+    separation = coordinates[0].separation(coordinates).to_value(u.arcsec)
+    indices = np.flatnonzero(np.isfinite(separation) &
+                             (separation <= radius_arcsec))
+    if not len(indices) or indices[0] != 0:
+        indices = np.insert(indices, 0, 0)
+    return indices
+
+
+def _finite_positive_scalar(value):
+    """Return a finite positive float, or ``None`` for unusable values.
+
+    Parameters
+    ----------
+    value : object
+        Candidate source flux scale, including masked table values.
+
+    Returns
+    -------
+    float or None
+        Positive finite value, or ``None`` when the input is unusable.
+    """
+
+    if np.ma.is_masked(value):
+        return None
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return None
+    return value if np.isfinite(value) and value > 0 else None
+
+
+def calc_v3pa(v3pa, stars, aperture,
+              source_search_radius_arcsec=SOURCE_SEARCH_RADIUS_ARCSEC):
+    """Render one MIRI/LRS position angle by rigid source translation.
+
+    Parameters
+    ----------
+    v3pa : float
+        Telescope V3 position angle in degrees.
+    stars : astropy.table.Table
+        Target and neighboring catalog sources. Row zero must be the target.
+    aperture : pysiaf.aperture.JwstAperture
+        MIRI slitless-prism aperture used for coordinate transformations.
+    source_search_radius_arcsec : float
+        Maximum separation of candidate contaminants from the target, in
+        arcseconds.
+
+    Returns
+    -------
+    dict
+        Target and contaminant detector images, extracted contamination,
+        wavelength calibration, extraction mask, and contributing-source
+        metadata for the requested position angle.
+
+    Raises
+    ------
+    ValueError
+        If the target does not have a finite, positive flux scale.
+    """
+
+    source_indices = nearby_source_indices(
+        stars, source_search_radius_arcsec)
+    candidate_stars = stars[source_indices].copy()
+    xdet, ydet = aperture.reference_point('det')
+    xtel, ytel = aperture.det_to_tel(xdet, ydet)
+    attitude = pysiaf.utils.rotations.attitude_matrix(
+        xtel, ytel, candidate_stars['ra'][0], candidate_stars['dec'][0],
+        v3pa % 360)
+    offsets = source_offsets(candidate_stars, aperture, attitude)
+
+    target_fluxscale = _finite_positive_scalar(
+        candidate_stars['fluxscale'][0])
+    if target_fluxscale is None:
+        raise ValueError('The target does not have a valid flux scale.')
+    target_asset = load_trace(candidate_stars['Teff'][0])
+    target = target_asset.trace * target_fluxscale
+    contaminants = np.zeros(SHAPE, dtype=float)
+    included = []
+    intersecting = []
+    for index, star, (y_shift, x_shift) in zip(
+            source_indices[1:], candidate_stars[1:], offsets[1:]):
+        if star['type'] != 'STAR':
+            continue
+        fluxscale = _finite_positive_scalar(star['fluxscale'])
+        if fluxscale is None:
+            continue
+        # Padded rows extend beyond both detector edges, so only the unpadded
+        # cross-dispersion bound is safe to reject before rendering.
+        if abs(x_shift) >= SHAPE[1]:
+            continue
+        asset = load_trace(star['Teff'])
+        shifted = render_trace(asset, y_shift, x_shift)
+        if not np.any(shifted):
+            continue
+        contaminants += shifted * fluxscale
+        included.append(int(index))
+        overlap = shifted * target_asset.extraction_mask
+        if np.any(np.isfinite(overlap) & (overlap != 0)):
+            columns = star.colnames
+            name = next(
+                (str(star[column]) for column in ('name', 'source_id')
+                 if column in columns),
+                f'Source {index}')
+            intersecting.append({
+                'index': int(index),
+                'name': name,
+                'ra': float(star['ra']),
+                'dec': float(star['dec']),
+                'y_shift': int(y_shift),
+                'x_shift': int(x_shift),
+                'fluxscale': fluxscale,
+                'teff': float(star['Teff']),
+            })
+
+    fraction = contamination_fraction(
+        target, contaminants, target_asset.extraction_mask)
+    return {
+        'pa': v3pa,
+        'target': target,
+        'target_traces': [target],
+        'contaminants': contaminants,
+        'contamination': fraction,
+        'wavelength': target_asset.wavelength,
+        'valid_wavelength': target_asset.valid_wavelength,
+        'extraction_mask': target_asset.extraction_mask,
+        'included_sources': included,
+        'intersecting_sources': intersecting,
+    }
+
+
+def contamination_fraction(target, contaminants, mask,
+                           collapse_axis=CROSS_DISPERSION_AXIS):
+    """Calculate extracted contamination for one MIRI trace.
+
+    Parameters
+    ----------
+    target : numpy.ndarray
+        Target source-rate image.
+    contaminants : numpy.ndarray
+        Summed contaminating-source rate image with the same shape as
+        ``target``.
+    mask : numpy.ndarray
+        Extraction weights with the same shape as ``target``.
+    collapse_axis : int, optional
+        Detector axis to average over after applying ``mask``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Mean pixel contamination fraction along the retained spectral axis.
+        Channels containing no valid extraction pixels are NaN.
+    """
+
+    total = target + contaminants
+    fraction = np.divide(
+        contaminants,
+        total,
+        out=np.full_like(total, np.nan, dtype=float),
+        where=(total != 0) & np.isfinite(total),
+    )
+    # Pixels outside the target extraction must not participate in the mean.
+    # Multiplying them by zero is insufficient: an unrelated trace can make
+    # their fractions finite, causing those zeroes to dilute the in-aperture
+    # statistic merely because another source exists elsewhere on the array.
+    masked_fraction = np.where(mask > 0, fraction * mask, np.nan)
+    valid = np.isfinite(masked_fraction)
+    numerator = np.nansum(masked_fraction, axis=collapse_axis)
+    denominator = np.sum(valid, axis=collapse_axis)
+    return np.divide(
+        numerator, denominator,
+        out=np.full(np.shape(numerator), np.nan, dtype=float),
+        where=denominator > 0)

--- a/exoctk/contam_visibility/modes.py
+++ b/exoctk/contam_visibility/modes.py
@@ -10,6 +10,6 @@ CONTAM_VISIBILITY_MODES = (
      'NIRCam - Grism Time Series - F322W2 (Visibility Only)'),
     ('NRCA5_GRISM256_F444W',
      'NIRCam - Grism Time Series - F444W (Visibility Only)'),
-    ('MIRIM_SLITLESSPRISM', 'MIRI - LRS (Visibility Only)'),
+    ('MIRIM_SLITLESSPRISM_IP', 'MIRI - LRS - SLITLESSPRISM_IP'),
     ('NIRSpec', 'NIRSpec (Visibility Only)'),
 )

--- a/exoctk/contam_visibility/precompute.py
+++ b/exoctk/contam_visibility/precompute.py
@@ -23,6 +23,7 @@ import time
 from pathlib import Path
 
 from . import field_simulator as fs
+from . import miri_lrs
 from ..utils import get_target_data, get_canonical_name
 from ..pkgdata import resource_filename
 
@@ -46,6 +47,8 @@ def _get_shape(aperture):
         n_traces, nrows, ncols = 3, 96, 2048
     elif aperture in ['NRCA5_41STRIPE1_DHS_F322W2', 'NRCA5_41STRIPE1_DHS_F444W']:
         n_traces, nrows, ncols = 10, 2128, 3192
+    elif aperture == miri_lrs.APERTURE:
+        n_traces, nrows, ncols = 1, *miri_lrs.SHAPE
     else:
         raise NameError(f"Did not recognize the aperture '{aperture}'")
     return n_traces, nrows, ncols
@@ -73,6 +76,8 @@ def save_exoplanet_data(filename, exoplanet_name, aperture, ra, dec, target_trac
     grp_name = exoplanet_name.strip().replace("/", "_")
 
     with h5py.File(filename, "a") as f:
+        if aperture == miri_lrs.APERTURE:
+            f.attrs['aperture'] = aperture
         if grp_name not in f:
             grp = f.create_group(grp_name)
             grp.attrs["name"] = exoplanet_name
@@ -112,6 +117,24 @@ def save_exoplanet_data(filename, exoplanet_name, aperture, ra, dec, target_trac
         if "plane_index" not in grp:
             # Plane index placeholder
             grp.create_dataset("plane_index", shape=(0,), maxshape=(None,), dtype="int16")
+
+        if aperture == miri_lrs.APERTURE:
+            if 'wavelength' not in grp:
+                grp.create_dataset(
+                    'wavelength', shape=(nrows,), dtype='float64')
+            if 'valid_wavelength' not in grp:
+                grp.create_dataset(
+                    'valid_wavelength', shape=(nrows,), dtype='bool')
+            if 'extraction_mask' not in grp:
+                grp.create_dataset(
+                    'extraction_mask', shape=(nrows, ncols), dtype='float32')
+            if isinstance(goodPA_list, miri_lrs.PositionAngleResults):
+                grp.attrs['inaccessiblePA_list'] = goodPA_list.inaccessible
+
+            asset = miri_lrs.load_reference_trace()
+            grp['wavelength'][:] = asset.wavelength
+            grp['valid_wavelength'][:] = asset.valid_wavelength
+            grp['extraction_mask'][:, :] = asset.extraction_mask
 
         # --- Sparse contamination ---
         plane_index = np.where(contamination.any(axis=(1, 2)))[0]
@@ -200,6 +223,10 @@ def generate_database(target_names, filename='NIS_SUBSTRIP256_db.h5', aperture='
 
                     # Plane index placeholder
                     grp.create_dataset("plane_index", shape=(0,), maxshape=(None,), dtype="int16")
+                    if aperture == miri_lrs.APERTURE:
+                        grp.create_dataset('wavelength', shape=(nrows,), dtype='float64')
+                        grp.create_dataset('valid_wavelength', shape=(nrows,), dtype='bool')
+                        grp.create_dataset('extraction_mask', shape=(nrows, ncols), dtype='float32')
 
                     count += 1
 

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -383,7 +383,10 @@ def pa_contam():
 def run_gaia_query_task(self, params):
     task_uuid = f"{self.request.id}"
     params["task"] = self
-    stars = fs.find_sources(params["ra"], params["dec"], target_date=params["target_date"])
+    stars = fs.find_sources(
+        params["ra"], params["dec"],
+        width=fs.source_query_width(params["aperture"]),
+        target_date=params["target_date"])
 
     self.update_state(state="SAVING STARS")
     stars_file = os.path.join(os.environ['SHARED_DATA_DIR'], f'{task_uuid}_stars.pickle')
@@ -515,7 +518,7 @@ def contam_visibility():
                 not fs.contamination_supported(form.inst.data)):
             form.calculate_contam_submit.disabled = True
             form.inst.errors.append(
-                'Contamination calculations are available only for SOSS and DHS modes.')
+                'Contamination calculations are available only for NIRISS/SOSS, NIRCam/DHS, and MIRI/LRS modes.')
             return render_template('contam_visibility.html', form=form)
 
         if form.inst.data == "NIRSpec":
@@ -684,14 +687,23 @@ def contam_visibility():
             print("Loaded results")
             os.remove(results_file)
 
-            # Get bad PA list from missing angles between 0 and 360
-            badPAs = [pa for pa in np.arange(0, 360) if pa not in results]
+            # MIRI calculates every orientation, so observability must come
+            # from its explicit year-specific metadata rather than missing
+            # contamination planes.
+            badPAs = fs.unobservable_v3pas(results)
             print("Made PA list")
 
             if fs.contamination_supported(form.inst.data):
                 pctlines = fs.fraction_contaminated(
                     form.inst.data, targframe, starcube)
-                if form.inst.data.startswith('NIS'):
+                if form.inst.data == fs.miri_lrs.APERTURE:
+                    asset = fs.miri_lrs.load_reference_trace()
+                    contam_plot = cf.contam_slider_plot(
+                        pctlines, badPAs, wavelength=asset.wavelength,
+                        trace_names=['MIRI LRS'],
+                        contamination_labels=['Spectrum'], y_max=0.1)
+                    print("Made MIRI LRS contamination plot")
+                elif form.inst.data.startswith('NIS'):
                     contam_plot = cf.soss_contamination_plot_layout(
                         targframe, starcube, pctlines, badPAs,
                         form.inst.data, form.targname.data)
@@ -699,7 +711,7 @@ def contam_visibility():
                 else:
                     contam_plot = cf.contam_slider_plot(
                         pctlines, badPAs, instrument=form.inst.data)
-                    print("Made contamination slider plot")
+                    print("Made DHS contamination plot")
             else:
                 # Retain the legacy image plot for any future mode that has not
                 # adopted the common contamination-slider representation.

--- a/exoctk/exoctk_app/templates/contam_visibility.html
+++ b/exoctk/exoctk_app/templates/contam_visibility.html
@@ -34,7 +34,8 @@
                    mode === 'NIS_SUBSTRIP96' ||
                    mode === 'NIS_SUBSTRIP256' ||
                    mode === 'NRCA5_41STRIPE1_DHS_F322W2' ||
-                   mode === 'NRCA5_41STRIPE1_DHS_F444W';
+                   mode === 'NRCA5_41STRIPE1_DHS_F444W' ||
+                   mode === 'MIRIM_SLITLESSPRISM_IP';
         }
 
         function updateContaminationButton() {
@@ -244,7 +245,7 @@
                     {{ form.calculate_contam_submit(disabled=form.calculate_contam_submit.disabled, class="btn btn-success") }}
                     <span id="helpBlock" class="help-block">Calculate the visibility and the contamination. Please be patient, this calculation takes a while.</span>
                     <span id="contamination-unavailable" class="help-block" style="color: red;" hidden>
-                        Contamination calculations are available only for SOSS and DHS modes.
+                        Contamination calculations are available only for NIRISS/SOSS, NIRCam/DHS, and MIRI/LRS modes.
                     </span>
                 </p>
             </div>

--- a/exoctk/exoctk_app/templates/contam_visibility_results.html
+++ b/exoctk/exoctk_app/templates/contam_visibility_results.html
@@ -50,7 +50,6 @@
                 <h3> Target Contamination for PA={{ pa_val }} at Epoch={{ epoch }}</h3>
             {% endif %}
             <br>
-            <!-- <p><img src="data:image/png;base64,{{ contam_plot | safe }}" alt="contam" width='1000px'></p> -->
     		<p>
                 {% if pa_val == -1 %}
                     <ul>
@@ -61,11 +60,6 @@
                         <li>Grey regions mark V3 position angles at which the target is not observable during the selected epoch.</li>
                     </ul>
                     <br><br>
-<!--                    <ul>-->
-<!--                        <li>The top plot shows the fractional contamination of orders 1 (blue), 2 (red), and 3 (green) in each detector column.</li>-->
-<!--                        <li>Drag the slider or use arrow keys to display the contamination at different position angles.</li>-->
-<!--                        <li>The bottom plot shows the contamination at the selected PA as well as the positions angles where the target is not visible (grey).</li>-->
-<!--                    </ul>-->
                 {% else %}
                     <ul>
                         <li>The top plot shows the simulated observation at the given position angle.</li>

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -20,20 +20,27 @@ Use
         pytest -s test_contam_visibility.py
 """
 
+import json
 import os
+import pickle
 import sys
 import warnings
 from pathlib import Path
 
 import numpy as np
 import pytest
+import pysiaf
 
 from pandas import DataFrame
+from astropy.io import fits
 from astropy.table import MaskedColumn, Table
 import astropy.units as u
 
 from exoctk.contam_visibility import field_simulator
 from exoctk.contam_visibility import contamination_figure
+from exoctk.contam_visibility import miri_lrs
+from exoctk.contam_visibility import make_miri_lrs_traces
+from exoctk.contam_visibility import precompute
 from exoctk.contam_visibility import resolve
 from exoctk.contam_visibility import new_vis_plot
 from exoctk.contam_visibility import contamination_figure
@@ -134,6 +141,60 @@ def test_precomputed_field_simulation():
     targframe, starcube, results = field_simulator.field_simulation(targname=bad_targname, aperture=aperture, target_db=target_db)
 
     assert isinstance(targframe, (np.ndarray, list)) and isinstance(starcube, (np.ndarray, list))
+
+
+def test_miri_position_angle_failure_is_raised(monkeypatch):
+    """LRS propagates a PA calculation failure like every other mode."""
+
+    aperture_name = miri_lrs.APERTURE
+    full_name = field_simulator.APERTURES[aperture_name]['full']
+
+    class FakeFullAperture:
+        @staticmethod
+        def corners(frame):
+            assert frame == 'det'
+            return np.array([0., 1.]), np.array([0., 1.])
+
+    class FakeScienceAperture:
+        XSciSize = 2
+        YSciSize = 2
+
+    class FakeSiaf:
+        apertures = {
+            full_name: FakeFullAperture(),
+            aperture_name: FakeScienceAperture(),
+        }
+
+    positions = DataFrame({
+        'V3PA_min_pa_angle': [0.],
+        'V3PA_nominal_angle': [0.],
+        'V3PA_max_pa_angle': [0.],
+    })
+    monkeypatch.delenv('EXOCTK_CONTAM_CACHE', raising=False)
+    monkeypatch.setattr(field_simulator, 'check_for_data', lambda *args: None)
+    monkeypatch.setattr(field_simulator.pysiaf, 'Siaf', lambda inst: FakeSiaf())
+    monkeypatch.setattr(field_simulator, 'find_sources', lambda *args, **kwargs: Table())
+    monkeypatch.setattr(
+        field_simulator, 'get_exoplanet_positions',
+        lambda *args, **kwargs: positions)
+    monkeypatch.setattr(
+        field_simulator, 'calculation_v3pas',
+        lambda aperture, observable: np.array([0, 1]))
+
+    def calculate(pa, **kwargs):
+        if pa == 1:
+            raise RuntimeError('synthetic PA failure')
+        return {
+            'pa': int(pa),
+            'target_traces': [np.ones((2, 2))],
+            'contaminants': np.zeros((2, 2)),
+        }
+
+    monkeypatch.setattr(field_simulator, 'calc_v3pa', calculate)
+
+    with pytest.raises(RuntimeError, match='synthetic PA failure'):
+        field_simulator.field_simulation(
+            ra=10., dec=20., aperture=aperture_name)
 
 
 def test_resolve_target():
@@ -733,6 +794,7 @@ def test_fraction_contaminated_ignores_flux_outside_extraction(
     'NIS_SUBSTRIP256',
     'NRCA5_41STRIPE1_DHS_F322W2',
     'NRCA5_41STRIPE1_DHS_F444W',
+    'MIRIM_SLITLESSPRISM_IP',
 ])
 def test_contamination_supported(aperture):
     """The web interface enables contamination only for its supported modes."""
@@ -778,7 +840,6 @@ def test_substrip96_contamination_plot_omits_order2(monkeypatch):
     plot = contamination_figure.contam(Cube(), 'NIS_SUBSTRIP96')
 
     assert len(plot.children) == 2
-
 
 def test_substrip96_slider_omits_uncalculated_orders():
     """The web slider exposes only the calculated SUBSTRIP96 order."""
@@ -847,3 +908,585 @@ def test_dhs_modes_available_in_web_form():
     choices = dict(CONTAM_VISIBILITY_MODES)
     assert choices['NRCA5_41STRIPE1_DHS_F322W2'] == 'NIRCam - DHS - F322W2'
     assert choices['NRCA5_41STRIPE1_DHS_F444W'] == 'NIRCam - DHS - F444W'
+
+
+def _synthetic_miri_frames(contaminant_scale=0.):
+    mask = np.zeros(miri_lrs.SHAPE)
+    mask[:, 28:40] = 1
+    target = mask.copy()
+    contaminant = mask * contaminant_scale
+    return target, contaminant, mask
+
+
+def test_miri_isolated_and_overlapping_contamination():
+    """MIRI preserves ExoCTK's pixel-level fraction-then-mean statistic."""
+
+    target, isolated, mask = _synthetic_miri_frames(0.)
+    result = miri_lrs.contamination_fraction(target, isolated, mask)
+    assert np.allclose(result, 0.)
+
+    target, overlapping, mask = _synthetic_miri_frames(1.)
+    result = miri_lrs.contamination_fraction(target, overlapping, mask)
+    assert np.allclose(result, 0.5)
+
+
+def test_miri_contamination_empty_channels_do_not_warn():
+    """Expected empty LRS wavelength channels remain NaN without warnings."""
+
+    target = np.array([[1., 0.], [1., 0.]])
+    contaminants = np.zeros_like(target)
+    mask = np.ones_like(target)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        result = miri_lrs.contamination_fraction(
+            target, contaminants, mask, collapse_axis=0)
+
+    assert result[0] == pytest.approx(0.)
+    assert np.isnan(result[1])
+    assert not any('Mean of empty slice' in str(warning.message)
+                   for warning in caught)
+
+
+def test_miri_fluxscale_changes_result_predictably():
+    target, contaminant, mask = _synthetic_miri_frames(3.)
+    result = miri_lrs.contamination_fraction(target, contaminant, mask)
+    assert np.allclose(result, 0.75)
+
+
+def test_miri_contamination_ignores_flux_outside_extraction():
+    """An off-aperture trace must not dilute the in-aperture mean."""
+
+    target, contaminant, mask = _synthetic_miri_frames(1.)
+    expected = miri_lrs.contamination_fraction(target, contaminant, mask)
+    contaminant[:, :10] = 100.
+
+    result = miri_lrs.contamination_fraction(target, contaminant, mask)
+
+    assert np.array_equal(result, expected)
+
+
+def test_miri_all_pa_reducer_ignores_flux_outside_extraction():
+    """The slider reducer must preserve the same MIRI mask semantics."""
+
+    target, contaminant, mask = _synthetic_miri_frames(1.)
+    contaminant_cube = np.stack([contaminant, contaminant.copy()])
+    expected = field_simulator.fraction_contaminated(
+        miri_lrs.APERTURE, [target], contaminant_cube,
+        trace_masks=[mask], collapse_axis=miri_lrs.CROSS_DISPERSION_AXIS)[0]
+    contaminant_cube[1, :, :10] = 100.
+
+    result = field_simulator.fraction_contaminated(
+        miri_lrs.APERTURE, [target], contaminant_cube,
+        trace_masks=[mask], collapse_axis=miri_lrs.CROSS_DISPERSION_AXIS)[0]
+
+    assert np.array_equal(result[0], expected[0])
+    assert np.array_equal(result[1], expected[1])
+
+
+def test_miri_ignores_contaminant_with_masked_fluxscale(monkeypatch):
+    """A masked flux scale must never be interpreted as unity."""
+
+    trace = np.ones(miri_lrs.SHAPE)
+    asset = miri_lrs.MiriTraceAsset(
+        trace=trace,
+        wavelength=np.linspace(13.8, 5., miri_lrs.SHAPE[0]),
+        extraction_mask=trace.copy(),
+        valid_wavelength=np.ones(miri_lrs.SHAPE[0], dtype=bool),
+        reference_pixel=(290, 34),
+        metadata={},
+    )
+    monkeypatch.setattr(miri_lrs, 'load_trace', lambda teff: asset)
+    stars = Table({
+        'name': ['target', 'unknown-flux source'],
+        'ra': [10., 10.],
+        'dec': [20., 20.],
+        'Teff': [5000., 4000.],
+        'type': ['STAR', 'STAR'],
+        **{name: np.zeros(2) for name in
+           ('xdet', 'ydet', 'xtel', 'ytel', 'xsci', 'ysci')},
+    })
+    stars['fluxscale'] = MaskedColumn(
+        [1., 1.], mask=[False, True])
+    aperture = pysiaf.Siaf('MIRI')[miri_lrs.APERTURE]
+
+    result = miri_lrs.calc_v3pa(0., stars, aperture)
+
+    assert np.allclose(result['contaminants'], 0.)
+    assert np.allclose(result['contamination'], 0.)
+
+
+@pytest.mark.parametrize(
+    'shift, expected',
+    [((2, 3), (2, 3)), ((-2, -3), (0, 0))],
+)
+def test_miri_trace_shift_sign_and_clipping(shift, expected):
+    trace = np.zeros((4, 4))
+    trace[0, 0] = 1
+    shifted = miri_lrs.shift_trace(trace, *shift, shape=(4, 4))
+    if shift[0] < 0:
+        assert not shifted.any()
+    else:
+        assert shifted[expected] == 1
+
+
+def test_miri_expanded_source_rate_moves_onto_detector_after_shift():
+    trace = np.zeros(miri_lrs.SHAPE)
+    trace[-1, 34] = 10.
+    trace[0, 34] = 20.
+    wavelength = np.linspace(5.02, 13.863, miri_lrs.SHAPE[0])
+    red_extension = np.zeros((2, miri_lrs.SHAPE[1]))
+    red_extension[0, 34] = 5.
+    blue_extension = np.zeros((2, miri_lrs.SHAPE[1]))
+    blue_extension[-1, 34] = 4.
+    asset = miri_lrs.MiriTraceAsset(
+        trace=trace,
+        wavelength=wavelength,
+        extraction_mask=np.ones(miri_lrs.SHAPE),
+        valid_wavelength=np.isfinite(wavelength),
+        reference_pixel=(290, 34),
+        metadata={},
+        red_extension=red_extension,
+        red_extension_y0=miri_lrs.SHAPE[0],
+        blue_extension=blue_extension,
+        blue_extension_y0=-2,
+    )
+
+    assert not np.any(miri_lrs.render_trace(asset, 0, 0) - trace)
+    upstream = miri_lrs.render_trace(asset, -1, 0)
+    assert upstream[-2, 34] == trace[-1, 34]
+    assert upstream[-1, 34] == red_extension[0, 34]
+    downstream = miri_lrs.render_trace(asset, 1, 0)
+    assert downstream[0, 34] == blue_extension[-1, 34]
+    assert downstream[1, 34] == trace[0, 34]
+
+
+def test_miri_axes_mask_and_wavelength_contract():
+    target, _, mask = _synthetic_miri_frames()
+    wavelength = np.full(miri_lrs.SHAPE[0], np.nan)
+    wavelength[6:-6] = np.linspace(13.8, 5.0, miri_lrs.SHAPE[0] - 12)
+    valid = np.isfinite(wavelength)
+    assert target.shape == mask.shape == (384, 68)
+    assert miri_lrs.DISPERSION_AXIS == 0
+    assert miri_lrs.CROSS_DISPERSION_AXIS == 1
+    assert valid.sum() == 372
+    assert np.all(np.diff(wavelength[valid]) < 0)
+    assert np.all(target[mask.astype(bool)] > 0)
+
+    # Native MIRI dispersion is detector Y, so all-PA reduction must collapse
+    # detector X and retain 384 wavelength rows.
+    cube_result = field_simulator.fraction_contaminated(
+        miri_lrs.APERTURE, [target], np.zeros_like(target),
+        trace_masks=[mask], collapse_axis=miri_lrs.CROSS_DISPERSION_AXIS)
+    assert cube_result[0].shape == (1, miri_lrs.SHAPE[0])
+
+
+def test_miri_result_pickle_round_trip():
+    target, contaminants, mask = _synthetic_miri_frames(0.25)
+    result = {
+        'pa': 42., 'target': target, 'contaminants': contaminants,
+        'extraction_mask': mask, 'wavelength': np.linspace(13., 5., 384),
+    }
+    restored = pickle.loads(pickle.dumps(result))
+    assert restored['pa'] == 42.
+    for key in ('target', 'contaminants', 'extraction_mask', 'wavelength'):
+        assert np.array_equal(restored[key], result[key])
+    pa_status = miri_lrs.PositionAngleResults([10, 11], [0, 1])
+    restored_status = pickle.loads(pickle.dumps(pa_status))
+    assert restored_status == [10, 11]
+    assert restored_status.inaccessible == [0, 1]
+
+
+def test_miri_precompute_can_add_target_to_existing_database(
+        tmp_path, monkeypatch):
+    """Living caches retain the LRS wavelength products."""
+
+    trace = np.ones(miri_lrs.SHAPE)
+    wavelength = np.linspace(5., 14., miri_lrs.SHAPE[0])
+    mask = np.ones(miri_lrs.SHAPE)
+    asset = miri_lrs.MiriTraceAsset(
+        trace=trace, wavelength=wavelength, extraction_mask=mask,
+        valid_wavelength=np.ones(miri_lrs.SHAPE[0], dtype=bool),
+        reference_pixel=(0, 0), metadata={'source': 'synthetic'})
+    monkeypatch.setattr(precompute.miri_lrs, 'load_trace', lambda teff: asset)
+
+    filename = tmp_path / 'miri-cache.h5'
+    contamination = np.zeros((360, *miri_lrs.SHAPE))
+    contamination[240] = 0.5
+    pa_results = miri_lrs.PositionAngleResults(
+        successful=[240], inaccessible=[0, 1])
+    precompute.save_exoplanet_data(
+        filename, 'HD 189733 b', miri_lrs.APERTURE, 300.182, 22.711,
+        trace[None], contamination, goodPA_list=pa_results)
+
+    with precompute.h5py.File(filename, 'r') as handle:
+        group = handle['HD 189733 b']
+        assert group.attrs['filled']
+        assert list(group['plane_index'][:]) == [240]
+        assert list(group.attrs['inaccessiblePA_list']) == [0, 1]
+        np.testing.assert_array_equal(group['wavelength'][:], wavelength)
+        np.testing.assert_array_equal(group['extraction_mask'][:], mask)
+
+
+def test_miri_pa_rotation_uses_siaf_coordinates():
+    aperture = pysiaf.Siaf('MIRI')[miri_lrs.APERTURE]
+    xdet, ydet = aperture.reference_point('det')
+    xtel, ytel = aperture.det_to_tel(xdet, ydet)
+    ra, dec = 10., 20.
+    attitude0 = pysiaf.utils.rotations.attitude_matrix(
+        xtel, ytel, ra, dec, 0.)
+    source_ra, source_dec = pysiaf.utils.rotations.tel_to_sky(
+        attitude0, xtel + 1., ytel)
+    stars = Table({
+        'ra': [ra, source_ra.to_value(u.deg)],
+        'dec': [dec, source_dec.to_value(u.deg)],
+        **{name: np.zeros(2) for name in
+           ('xdet', 'ydet', 'xtel', 'ytel', 'xsci', 'ysci')},
+    })
+    offset0 = miri_lrs.source_offsets(stars.copy(), aperture, attitude0)[1]
+    attitude90 = pysiaf.utils.rotations.attitude_matrix(
+        xtel, ytel, ra, dec, 90.)
+    offset90 = miri_lrs.source_offsets(stars.copy(), aperture, attitude90)[1]
+    assert offset0 != offset90
+    assert np.hypot(*offset0) == pytest.approx(np.hypot(*offset90), abs=1)
+
+
+def test_hd189733b_moves_toward_lower_detector_rows_at_v3pa_238():
+    """The upstream companion's +Y_SCI offset maps to a lower array row."""
+
+    stars = Table({
+        'ra': [300.182137, 300.1789791392316],
+        'dec': [22.710853, 22.707659537029453],
+        **{name: np.zeros(2) for name in
+           ('xdet', 'ydet', 'xtel', 'ytel', 'xsci', 'ysci')},
+    })
+    aperture = pysiaf.Siaf('MIRI')[miri_lrs.APERTURE]
+    xdet, ydet = aperture.reference_point('det')
+    xtel, ytel = aperture.det_to_tel(xdet, ydet)
+    attitude = pysiaf.utils.rotations.attitude_matrix(
+        xtel, ytel, stars['ra'][0], stars['dec'][0], 238.)
+
+    offsets = miri_lrs.source_offsets(stars, aperture, attitude)
+
+    assert offsets == [(0, 0), (-132, 49)]
+
+
+def test_miri_v3pa_has_no_additional_aperture_angle(monkeypatch):
+    """MIRI source placement passes V3PA directly to the SIAF attitude."""
+
+    aperture = pysiaf.Siaf('MIRI')[miri_lrs.APERTURE]
+    xdet, ydet = aperture.reference_point('det')
+    xtel, ytel = aperture.det_to_tel(xdet, ydet)
+    ra, dec, v3pa = 10., 20., 123.4
+    attitude = pysiaf.utils.rotations.attitude_matrix(
+        xtel, ytel, ra, dec, v3pa)
+    source_ra, source_dec = pysiaf.utils.rotations.tel_to_sky(
+        attitude, xtel + 5., ytel - 2.)
+    stars = Table({
+        'name': ['target', 'offset source'],
+        'ra': [ra, source_ra.to_value(u.deg)],
+        'dec': [dec, source_dec.to_value(u.deg)],
+        'Teff': [5000., 4000.],
+        'fluxscale': [1., 0.1],
+        'type': ['STAR', 'STAR'],
+        **{name: np.zeros(2) for name in
+           ('xdet', 'ydet', 'xtel', 'ytel', 'xsci', 'ysci')},
+    })
+    expected = miri_lrs.source_offsets(
+        stars.copy(), aperture, attitude)[1]
+    trace = np.ones(miri_lrs.SHAPE)
+    asset = miri_lrs.MiriTraceAsset(
+        trace=trace,
+        wavelength=np.linspace(13.8, 5., miri_lrs.SHAPE[0]),
+        extraction_mask=trace.copy(),
+        valid_wavelength=np.ones(miri_lrs.SHAPE[0], dtype=bool),
+        reference_pixel=(290, 34),
+        metadata={},
+    )
+    monkeypatch.setattr(miri_lrs, 'load_trace', lambda teff: asset)
+
+    result = miri_lrs.calc_v3pa(v3pa, stars, aperture)
+    source = result['intersecting_sources'][0]
+
+    assert (source['y_shift'], source['x_shift']) == expected
+
+
+def test_miri_nearby_source_pruning_is_conservative():
+    stars = Table({
+        'ra': [10., 10.005, 10.1],
+        'dec': [20., 20., 20.],
+    })
+    indices = miri_lrs.nearby_source_indices(stars, 60.)
+    assert np.array_equal(indices, [0, 1])
+
+
+def test_miri_source_query_covers_pruning_radius():
+    width = field_simulator.source_query_width(miri_lrs.APERTURE)
+    enclosing_radius = np.hypot(width, width) / 2.
+    assert enclosing_radius.to_value(u.arcsec) == pytest.approx(60.)
+    assert field_simulator.source_query_width(
+        'NIS_SUBSTRIP256') == 7.5 * u.arcmin
+
+
+def test_miri_trace_assets_are_cached(tmp_path):
+    trace_dir = (tmp_path / 'exoctk_contam' / 'traces' /
+                 miri_lrs.APERTURE)
+    trace_dir.mkdir(parents=True)
+    reference_teff = 4000
+    path = trace_dir / f'{miri_lrs.APERTURE}_{reference_teff}.fits'
+    header = fits.Header({
+        'APERTURE': miri_lrs.APERTURE,
+        'REFYPIX': 290,
+        'REFXPIX': 34,
+        'METAJSON': json.dumps({
+            'blue_extension_y0': -2,
+            'red_extension_y0': miri_lrs.SHAPE[0],
+        }),
+    })
+    fits.HDUList([
+        fits.PrimaryHDU(header=header),
+        fits.ImageHDU(np.ones(miri_lrs.SHAPE), name='TRACE'),
+        fits.ImageHDU(np.arange(miri_lrs.SHAPE[0]), name='WAVELENGTH'),
+        fits.ImageHDU(np.ones(miri_lrs.SHAPE), name='EXTRACTION_MASK'),
+        fits.ImageHDU(np.ones(miri_lrs.SHAPE[0]), name='VALID_WAVELENGTH'),
+        fits.ImageHDU(np.ones((2, miri_lrs.SHAPE[1])),
+                      name='BLUE_EXTENSION'),
+        fits.ImageHDU(np.ones((6, miri_lrs.SHAPE[1])),
+                      name='RED_EXTENSION'),
+    ]).writeto(path)
+
+    miri_lrs.load_trace.cache_clear()
+    first = miri_lrs.load_trace(reference_teff, str(tmp_path))
+    path.unlink()
+    second = miri_lrs.load_trace(reference_teff, str(tmp_path))
+    assert second is first
+    assert miri_lrs.load_trace.cache_info().hits == 1
+    miri_lrs.load_trace.cache_clear()
+
+
+def test_miri_reference_trace_uses_named_calibration_asset(monkeypatch):
+    """Shared calibration lookups use the documented reference asset."""
+
+    loaded = []
+    sentinel = object()
+
+    def load_trace(teff, exoctk_data=None):
+        loaded.append((teff, exoctk_data))
+        return sentinel
+
+    monkeypatch.setattr(miri_lrs, 'load_trace', load_trace)
+
+    assert miri_lrs.load_reference_trace('/test/data') is sentinel
+    assert loaded == [(4000, '/test/data')]
+
+
+def test_miri_product_retains_detector_rows_outside_wavelength_grid():
+    detector = np.zeros((427, 55))
+    detector[0, :] = 7.
+    detector[21, :] = 6.
+    detector[22, :] = 1.
+    detector[27, :] = 2.
+    detector[28, :] = 3.
+    detector[405, :] = 4.
+    detector[406, :] = 5.
+    report = {
+        '1d': {'wave_pix': np.linspace(13.86, 5.02, 372)},
+        'scalar': {'extraction_area': 12.},
+    }
+
+    (trace, wavelength, valid, mask, blue_extension, red_extension,
+     registration) = make_miri_lrs_traces._miri_product(
+        report, detector, 1.32)
+
+    assert np.all(trace[0, 7:62] == 1.)
+    assert np.all(trace[5, 7:62] == 2.)
+    assert np.all(trace[6, 7:62] == 3.)
+    assert np.all(trace[-1, 7:62] == 4.)
+    assert np.all(blue_extension[0, 7:62] == 7.)
+    assert np.all(blue_extension[-1, 7:62] == 6.)
+    assert np.all(red_extension[0, 7:62] == 5.)
+    assert registration['pandeia_detector_row0'] == 22
+    assert registration['pandeia_detector_product'] == 'noiseless_source_rate'
+    assert registration['blue_extension_y0'] == -22
+    assert registration['red_extension_y0'] == miri_lrs.SHAPE[0]
+    assert wavelength[6] == pytest.approx(5.02)
+    assert wavelength[377] == pytest.approx(13.86)
+    assert np.all(np.diff(wavelength[valid]) > 0.)
+    assert np.count_nonzero(valid) == 372
+    assert np.count_nonzero(mask) == 372 * 12
+
+
+def test_miri_product_registers_extended_projection_to_native_grid():
+    detector = np.zeros((439, 55))
+    detector[22, :] = 1.
+    detector[405, :] = 2.
+    detector[406, :] = 3.
+    report = {
+        '1d': {'wave_pix': np.linspace(14.015, 5.02, 384)},
+        'scalar': {'extraction_area': 12.},
+    }
+    calibrated = np.linspace(13.86, 5.02, 372)
+
+    (trace, wavelength, valid, mask, blue_extension, red_extension,
+     registration) = make_miri_lrs_traces._miri_product(
+        report, detector, 1.32, calibrated_wave=calibrated)
+
+    assert np.all(trace[0, 7:62] == 1.)
+    assert np.all(trace[-1, 7:62] == 2.)
+    assert np.all(red_extension[0, 7:62] == 3.)
+    assert registration['pandeia_detector_row0'] == 22
+    assert registration['pandeia_projected_wavelength_rows'] == 384
+    assert registration['pandeia_calibrated_wavelength_rows'] == 372
+    assert wavelength[6] == pytest.approx(5.02)
+    assert wavelength[377] == pytest.approx(13.86)
+    assert np.count_nonzero(valid) == 372
+    assert np.count_nonzero(mask) == 372 * 12
+
+
+def test_miri_extended_wave_grid_reaches_reference_response_zero():
+    native = np.linspace(5., 13.86, 380)
+    extended = make_miri_lrs_traces._extended_miri_wave_pix(
+        native, 14.01584)
+
+    assert np.array_equal(extended[:len(native)], native)
+    assert extended[-1] == pytest.approx(14.01584)
+    assert np.all(np.diff(extended) > 0.)
+    assert np.max(np.diff(extended)[len(native) - 1:-1]) < 0.03
+    assert len(extended) > len(native)
+
+
+def test_miri_templates_use_gaia_g_normalization():
+    """Template normalization must match field_simulator's Gaia flux ratios."""
+
+    normalization = make_miri_lrs_traces._scene(4000, 10.)[
+        'spectrum']['normalization']
+
+    assert normalization == {
+        'type': 'photsys',
+        'bandpass': 'gaia,g',
+        'norm_flux': 10.,
+        'norm_fluxunit': 'vegamag',
+    }
+
+
+def test_miri_observable_pa_ranges_use_v3pa_not_instrument_angle():
+    """The all-PA renderer must not apply the SIAF angle a second time."""
+
+    v3pas = np.arange(87., 107.)
+    table = DataFrame({
+        'V3PA_min_pa_angle': v3pas,
+        'V3PA_nominal_angle': v3pas,
+        'V3PA_max_pa_angle': v3pas,
+        'MIRI_min_pa_angle': v3pas + 4.83544897,
+        'MIRI_nominal_angle': v3pas + 4.83544897,
+        'MIRI_max_pa_angle': v3pas + 4.83544897,
+    })
+    position_angles, bounds, sampled = (
+        field_simulator.observable_v3pa_ranges(table))
+    assert bounds == [(87, 106)]
+    assert np.array_equal(position_angles, np.arange(87, 107))
+    assert np.array_equal(sampled, np.arange(87, 107))
+
+
+def test_miri_calculates_every_pa_but_other_modes_do_not():
+    observable = np.arange(87, 107)
+
+    assert np.array_equal(
+        field_simulator.calculation_v3pas(miri_lrs.APERTURE, observable),
+        np.arange(360))
+    assert np.array_equal(
+        field_simulator.calculation_v3pas('NIS_SUBSTRIP256', observable),
+        observable)
+
+
+def test_miri_observability_is_independent_of_calculated_pas():
+    results = miri_lrs.PositionAngleResults(
+        successful=np.arange(360), inaccessible=[0, 1, 359])
+
+    assert field_simulator.unobservable_v3pas(results) == [0, 1, 359]
+
+
+def test_miri_apt_v3pa_has_extraction_overlapping_source(monkeypatch):
+    """APT V3PA=53.82 places a nearby WASP-12 Gaia trace in the mask."""
+
+    trace = np.zeros(miri_lrs.SHAPE)
+    trace[:, 28:40] = 1.
+    wavelength = np.linspace(13.8, 5., miri_lrs.SHAPE[0])
+    mask = trace.copy()
+    asset = miri_lrs.MiriTraceAsset(
+        trace=trace, wavelength=wavelength, extraction_mask=mask,
+        valid_wavelength=np.ones(miri_lrs.SHAPE[0], dtype=bool),
+        reference_pixel=(290, 34), metadata={})
+    loaded_temperatures = []
+
+    def load_trace(teff):
+        loaded_temperatures.append(float(teff))
+        return asset
+
+    monkeypatch.setattr(miri_lrs, 'load_trace', load_trace)
+
+    # WASP-12 and VizieR/Gaia DR3 source 3435282866759615488.
+    stars = Table({
+        'name': ['WASP-12', '3435282866759615488', 'far source'],
+        'ra': [97.63664477033, 97.63945094102, 98.],
+        'dec': [29.67226537027, 29.67372250549, 30.],
+        'Teff': [6000., 4000., 5000.],
+        'fluxscale': [1., 0.1, 0.1],
+        'type': ['STAR', 'STAR', 'STAR'],
+        **{name: np.zeros(3) for name in
+           ('xdet', 'ydet', 'xtel', 'ytel', 'xsci', 'ysci')},
+    })
+    aperture = pysiaf.Siaf('MIRI')[miri_lrs.APERTURE]
+    result = miri_lrs.calc_v3pa(53.82, stars, aperture)
+
+    assert result['intersecting_sources'][0]['name'] == (
+        '3435282866759615488')
+    assert result['intersecting_sources'][0]['x_shift'] == -1
+    assert np.nanmax(result['contamination']) > 0
+    assert loaded_temperatures == [6000., 4000.]
+
+
+def test_miri_mode_available_in_web_form():
+    choices = dict(CONTAM_VISIBILITY_MODES)
+    assert choices['MIRIM_SLITLESSPRISM_IP'] == (
+        'MIRI - LRS - SLITLESSPRISM_IP')
+    assert 'MIRIM_SLITLESSPRISM' not in choices
+
+
+def test_miri_all_pa_plot_accepts_native_shape_and_wavelength():
+    fractions = [np.zeros((360, miri_lrs.SHAPE[0]))]
+    fractions[0][175, 100] = 0.05
+    wavelength = np.linspace(13.8, 5.0, miri_lrs.SHAPE[0])
+    plot = contamination_figure.contam_slider_plot(
+        fractions, [], wavelength=wavelength, trace_names=['MIRI LRS'],
+        y_max=0.1)
+    assert plot is not None
+    assert plot.children[0].y_range.end == pytest.approx(10.)
+    assert plot.children[-1].y_range.end == pytest.approx(10.)
+    assert plot.children[0].yaxis.axis_label == 'Contamination (%)'
+    assert plot.children[-1].yaxis.axis_label == 'Mean Contamination (%)'
+    plotted = plot.children[0].renderers[0].data_source.data['contam1']
+    assert np.nanmax(plotted) == pytest.approx(5.)
+    threshold_legend = plot.children[-1].below[-1]
+    labels = [item.label.value for item in threshold_legend.items]
+    assert 'Target not observable' in labels
+    assert 'Spectrum > 5.0% Contaminated' in labels
+
+
+def test_miri_single_pa_plot_accepts_runtime_result():
+    """The plotting module accepts the MIRI runtime result contract."""
+
+    valid = np.ones(miri_lrs.SHAPE[0], dtype=bool)
+    result = {
+        'pa': 42.,
+        'target': np.ones(miri_lrs.SHAPE),
+        'contaminants': np.zeros(miri_lrs.SHAPE),
+        'extraction_mask': np.ones(miri_lrs.SHAPE),
+        'valid_wavelength': valid,
+        'wavelength': np.linspace(5., 13.8, miri_lrs.SHAPE[0]),
+        'contamination': np.zeros(miri_lrs.SHAPE[0]),
+        'intersecting_sources': [],
+    }
+
+    plot = contamination_figure.miri_single_pa_plot(result)
+
+    assert len(plot.children) == 2

--- a/exoctk/utils.py
+++ b/exoctk/utils.py
@@ -10,6 +10,7 @@ import os
 import re
 import requests
 import shutil
+import subprocess
 import urllib
 import sys
 
@@ -88,6 +89,73 @@ if not ON_GITHUB_ACTIONS_OR_RTD:
         GENERICGRID_DIR = os.path.join(EXOCTK_DATA, 'generic/')
         GROUPS_INTEGRATIONS_DIR = os.path.join(EXOCTK_DATA, 'groups_integrations/')
         MODELGRID_DIR = os.path.join(EXOCTK_DATA, 'modelgrid/')
+
+
+def pandeia_provenance():
+    """Report the active Pandeia engine and reference-data provenance.
+
+    Pandeia is imported only when this function is called so that collecting
+    provenance remains optional for normal ExoCTK use.
+
+    Returns
+    -------
+    dict
+        Engine, source-revision, reference-data, and PSF-library versions.
+
+    Raises
+    ------
+    EnvironmentError
+        If Pandeia reference data or its PSF library is not configured.
+    """
+
+    import pandeia.engine
+    from pandeia.engine import config
+
+    module_path = os.path.realpath(pandeia.engine.__file__)
+    refdata = config.default_refdata()
+    psfs = config.default_psfs()
+    if not refdata or not psfs:
+        raise EnvironmentError(
+            'Set pandeia_refdata and PSF_DIR before collecting provenance')
+    with open(os.path.join(refdata, 'VERSION_DATA')) as handle:
+        data_version = handle.readline().strip()
+    with open(os.path.join(psfs, 'VERSION_PSF')) as handle:
+        psf_version = handle.readline().strip()
+
+    # Editable/source injection over an older environment can leave stale
+    # importlib metadata. The setup.py beside the imported source is the
+    # authoritative source declaration, so report it alongside the metadata.
+    setup_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(module_path))),
+        'setup.py')
+    declared_version = None
+    source_revision = None
+    if os.path.isfile(setup_path):
+        with open(setup_path) as handle:
+            match = re.search(r'version=["\']([^"\']+)', handle.read())
+        declared_version = match.group(1) if match else None
+        try:
+            source_revision = subprocess.check_output(
+                ['git', '-C', os.path.dirname(setup_path), 'describe',
+                 '--tags', '--always', '--dirty'], text=True).strip()
+        except (OSError, subprocess.CalledProcessError):
+            pass
+
+    provenance = {
+        'engine_declared_version':
+            declared_version or pandeia.engine.__version__,
+        'engine_metadata_version': pandeia.engine.__version__,
+        'engine_source_revision': source_revision,
+        'reference_data_version': data_version,
+        'psf_version': psf_version,
+    }
+    print(f'Pandeia module:  {module_path}')
+    print(f'Engine declared: {provenance["engine_declared_version"]}')
+    print(f'Engine metadata: {provenance["engine_metadata_version"]}')
+    print(f'Engine revision: {source_revision or "unavailable"}')
+    print(f'Reference data: {os.path.realpath(refdata)} ({data_version})')
+    print(f'PSF library:    {os.path.realpath(psfs)} ({psf_version})')
+    return provenance
 
 
 def blockPrint():


### PR DESCRIPTION
## Summary

Add contamination and visibility calculations for the MIRI/LRS slitless-prism mode.

## Changes

- Add Pandeia-based generation of temperature-dependent MIRI/LRS trace assets.
- Load precomputed trace assets at runtime without requiring Pandeia.
- Model neighboring sources using their detector positions, relative Gaia G-band fluxes, and effective temperatures.
- Retain off-detector spectral extensions so displaced traces are rendered correctly across detector boundaries.
- Calculate wavelength-dependent contamination within the target extraction mask.
- Evaluate contamination at all V3 position angles while independently shading angles that are not observable during the selected epoch.
- Add MIRI/LRS-specific wavelength axes, labels, source diagnostics, and the 10% contamination display range.
- Store the wavelength calibration, extraction mask, and visibility metadata in precomputed results.
- Expose `MIRI - LRS - SLITLESSPRISM_IP` through the web application.
- Add regression coverage for trace placement, wavelength registration, source filtering, caching, contamination reduction, position-angle handling, and plotting.
- Increase the Gunicorn timeout from 30 to 120 seconds so completed calculations have enough time to construct and render their result plots.
- Make the Selenium website test fail immediately upon detecting an HTTP 500 page instead of waiting for the full calculation timeout.

## Implementation notes

Pandeia is used only to generate the external trace assets. Normal contamination calculations load those precomputed assets from `EXOCTK_DATA` and do not import or execute Pandeia.

The implementation preserves the existing NIRISS/SOSS and NIRCam/DHS behavior while accounting for the different MIRI detector orientation, dispersion axis, extraction geometry, and wavelength coverage.

## Testing

- Manual testing performed with HD 189733 (which lies in quite a crowded field with many sources at many PAs that I could check against)