### PR TITLE
Restore bounded-memory caching for NIRCam DHS

### DIFF
--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -107,6 +107,17 @@ class DHSContaminationResult(Sequence):
         return len(self.order_fractions)
 
 
+def _cached_contam_result_available(group, compact_dhs=False):
+    """Return whether an HDF5 target group has a complete compatible result."""
+    if compact_dhs:
+        return (
+            "goodPA_list" in group.attrs
+            and "target_trace" in group
+            and "dhs_order_fractions" in group
+            and "dhs_position_angles" in group)
+    return "goodPA_list" in group.attrs
+
+
 def log_checkpoint(message):
     global _last_time
     now = datetime.now()
@@ -1392,7 +1403,7 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None,
     # Require None for binComp and target_date, since these change the results
     precomputed = False
     bounded_dhs = 'DHS' in aperture
-    if target_db is not None and not bounded_dhs:
+    if target_db is not None:
         logging.info(f"Found target DB {target_db}")
         if targname is not None:
             logging.info(f"Target name is {targname}")
@@ -1403,8 +1414,8 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None,
                     grp_name = get_canonical_name(targname).strip().replace("/", "_")
                     with h5py.File(target_db, "a") as f:
                         if grp_name in f:
-                            targframes, starcube, attrs = fetch_contam_results(targname, target_db)
-                            precomputed = "goodPA_list" in attrs
+                            precomputed = _cached_contam_result_available(
+                                f[grp_name], compact_dhs=bounded_dhs)
                 else:
                     logging.info("Can't precompute with non-current epoch")
             else:
@@ -1531,8 +1542,7 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None,
             for result in results:
                 starcube[result['pa'], :, :] = result['contaminants']
 
-        should_cache = all((
-            targname is not None, target_db is not None, not bounded_dhs))
+        should_cache = all((targname is not None, target_db is not None))
         if should_cache:
             logging.info(f"Saving {targname} to cache {target_db}")
             save_exoplanet_data(
@@ -1590,7 +1600,9 @@ def fetch_contam_results(exoplanet_name, db_filename):
     Returns
     -------
     target_trace : ndarray (n_traces, nrows, ncols)
-    contamination : ndarray (n_planes, nrows, ncols)
+    contamination : ndarray or DHSContaminationResult
+        A dense detector cube for legacy modes, or compact order fractions
+        for NIRCam DHS.
     attrs : dict (metadata)
     """
     name = get_canonical_name(exoplanet_name)
@@ -1602,13 +1614,23 @@ def fetch_contam_results(exoplanet_name, db_filename):
 
         grp = f[grp_name]
         target_trace = grp["target_trace"][:]
-        stored = grp["contamination"][:]
-        plane_index = grp["plane_index"][:]
+        if ("dhs_order_fractions" in grp
+                and "dhs_position_angles" in grp):
+            fractions = grp["dhs_order_fractions"]
+            contamination = DHSContaminationResult(
+                order_fractions=tuple(
+                    fractions[order] for order in range(fractions.shape[0])),
+                position_angles=grp["dhs_position_angles"][:])
+        else:
+            stored = grp["contamination"][:]
+            plane_index = grp["plane_index"][:]
 
-        # Reconstruct contamination cube
-        contamination = np.zeros((360, target_trace.shape[1], target_trace.shape[2]), dtype=stored.dtype)
-        if len(plane_index) > 0:
-            contamination[plane_index] = stored
+            # Reconstruct contamination cube
+            contamination = np.zeros(
+                (360, target_trace.shape[1], target_trace.shape[2]),
+                dtype=stored.dtype)
+            if len(plane_index) > 0:
+                contamination[plane_index] = stored
 
         attrs = dict(grp.attrs)
         for key in ('wavelength', 'valid_wavelength', 'extraction_mask'):

--- a/exoctk/contam_visibility/precompute.py
+++ b/exoctk/contam_visibility/precompute.py
@@ -67,10 +67,92 @@ def precomputed_target_list():
     return target_list
 
 
+def _save_compact_dhs(filename, exoplanet_name, ra, dec, target_trace,
+                      contamination, goodPA_list):
+    """Save a compact DHS result without assembling large intermediate arrays."""
+    if len(target_trace) == 0:
+        raise ValueError("target_trace must contain at least one spectral order")
+    first_trace = np.asarray(target_trace[0])
+    if first_trace.ndim != 2:
+        raise ValueError("Each target trace must have axes (row, column)")
+    n_traces = len(target_trace)
+    nrows, ncols = first_trace.shape
+    target_shape = (n_traces, nrows, ncols)
+    for trace in target_trace:
+        if np.asarray(trace).shape != (nrows, ncols):
+            raise ValueError("All target traces must have the same shape")
+
+    grp_name = exoplanet_name.strip().replace("/", "_")
+    with h5py.File(filename, "a") as f:
+        if grp_name not in f:
+            grp = f.create_group(grp_name)
+            grp.attrs["name"] = exoplanet_name
+            grp.attrs["ra"] = ra
+            grp.attrs["dec"] = dec
+            grp.attrs["filled"] = False
+
+        grp = f[grp_name]
+        if ("target_trace" in grp
+                and grp["target_trace"].shape != target_shape):
+            del grp["target_trace"]
+        if "target_trace" not in grp:
+            grp.create_dataset(
+                "target_trace",
+                shape=target_shape,
+                dtype="float32",
+                compression="gzip",
+                compression_opts=4,
+                chunks=(1, min(32, nrows), ncols))
+        for order, trace in enumerate(target_trace):
+            grp["target_trace"][order] = trace
+
+        grp.attrs["goodPA_list"] = goodPA_list
+
+        expected_shape = (
+            n_traces, len(contamination.position_angles), ncols)
+        if len(contamination.order_fractions) != n_traces:
+            raise ValueError("DHS result must contain one array per order")
+        for fractions in contamination.order_fractions:
+            if np.asarray(fractions).shape != expected_shape[1:]:
+                raise ValueError(
+                    "DHS order fractions must have shape "
+                    f"{expected_shape}; received incompatible order data")
+
+        for dataset_name in (
+                "contamination", "plane_index",
+                "dhs_order_fractions", "dhs_position_angles"):
+            if dataset_name in grp:
+                del grp[dataset_name]
+        grp.create_dataset(
+            "dhs_order_fractions",
+            shape=expected_shape,
+            dtype="float64",
+            compression="gzip",
+            compression_opts=4,
+            chunks=(1, min(32, expected_shape[1]), ncols))
+        for order, fractions in enumerate(contamination.order_fractions):
+            grp["dhs_order_fractions"][order] = fractions
+        grp.create_dataset(
+            "dhs_position_angles",
+            data=contamination.position_angles,
+            dtype="int16")
+        grp.attrs["filled"] = True
+
+    logging.info(
+        f"{exoplanet_name} saved "
+        f"({len(contamination.position_angles)} contamination planes)")
+
+
 def save_exoplanet_data(filename, exoplanet_name, aperture, ra, dec, target_trace, contamination, goodPA_list=np.arange(360)):
     """
     Save target trace and contamination (only non-zero planes) to HDF5 file.
     """
+    if isinstance(contamination, fs.DHSContaminationResult):
+        _save_compact_dhs(
+            filename, exoplanet_name, ra, dec, target_trace, contamination,
+            goodPA_list)
+        return
+
     n_traces, nrows, ncols = _get_shape(aperture)
 
     grp_name = exoplanet_name.strip().replace("/", "_")

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -1431,6 +1431,105 @@ def test_miri_precompute_can_add_target_to_existing_database(
         np.testing.assert_array_equal(group['extraction_mask'][:], mask)
 
 
+@pytest.mark.parametrize("aperture", [
+    "NRCA5_41STRIPE1_DHS_F322W2",
+    "NRCA5_41STRIPE1_DHS_F444W",
+])
+def test_dhs_compact_precompute_round_trip(tmp_path, monkeypatch, aperture):
+    """Compact DHS caches preserve the reconstituted order products exactly."""
+
+    filename = tmp_path / "dhs-cache.h5"
+    target = [
+        np.full((3, 7), order + 0.25, dtype=np.float32)
+        for order in range(2)]
+    fractions = [
+        np.arange(28, dtype=float).reshape(4, 7),
+        np.arange(28, 56, dtype=float).reshape(4, 7)]
+    fractions[0][1, 3] = np.nan
+    compact = field_simulator.DHSContaminationResult(
+        tuple(fractions), np.array([0, 12, 180, 359]))
+
+    # Simulate a legacy group: saving a compact result must replace, rather
+    # than reuse, its dense contamination placeholders.
+    with precompute.h5py.File(filename, "w") as handle:
+        group = handle.create_group("Synthetic b")
+        group.create_dataset(
+            "contamination", shape=(0, 3, 7), dtype="float32")
+        group.create_dataset("plane_index", shape=(0,), dtype="int16")
+
+    precompute.save_exoplanet_data(
+        filename, "Synthetic b", aperture, 10., 20., target, compact,
+        goodPA_list=np.array([0, 12, 180, 359]))
+    monkeypatch.setattr(
+        field_simulator, "get_canonical_name", lambda name: name)
+    restored_target, restored, _ = (
+        field_simulator.fetch_contam_results("Synthetic b", filename))
+
+    np.testing.assert_array_equal(restored_target, np.asarray(target))
+    assert isinstance(restored, field_simulator.DHSContaminationResult)
+    np.testing.assert_array_equal(
+        restored.position_angles, compact.position_angles)
+    for actual, expected in zip(restored, compact):
+        np.testing.assert_array_equal(actual, expected)
+        assert not actual.flags.writeable
+    assert not restored.position_angles.flags.writeable
+    with precompute.h5py.File(filename, "r") as handle:
+        group = handle["Synthetic b"]
+        assert "contamination" not in group
+        assert "plane_index" not in group
+        assert group["dhs_order_fractions"].shape == (2, 4, 7)
+
+
+def test_dhs_field_simulation_uses_compact_cache(tmp_path, monkeypatch):
+    """A complete compact DHS cache bypasses detector rendering."""
+
+    aperture = "NRCA5_41STRIPE1_DHS_F322W2"
+    filename = tmp_path / "dhs-cache.h5"
+    target = [np.ones((2, 5), dtype=np.float32)]
+    compact = field_simulator.DHSContaminationResult(
+        (np.arange(15, dtype=float).reshape(3, 5),),
+        np.array([0, 45, 359]))
+    precompute.save_exoplanet_data(
+        filename, "Synthetic b", aperture, 10., 20., target, compact,
+        goodPA_list=np.array([0, 45, 359]))
+
+    monkeypatch.setattr(field_simulator, "check_for_data", lambda *_: None)
+    monkeypatch.setattr(
+        field_simulator, "get_canonical_name", lambda name: name)
+    monkeypatch.setattr(
+        field_simulator, "get_target_data",
+        lambda name: ({"RA": 10., "DEC": 20.}, None))
+    monkeypatch.setattr(
+        field_simulator.pysiaf, "Siaf",
+        lambda *_: pytest.fail("cache hit unexpectedly rendered DHS"))
+
+    restored_target, restored, good_pas = field_simulator.field_simulation(
+        targname="Synthetic b", aperture=aperture, target_db=filename)
+
+    np.testing.assert_array_equal(restored_target, np.asarray(target))
+    np.testing.assert_array_equal(restored[0], compact[0])
+    np.testing.assert_array_equal(good_pas, [0, 45, 359])
+
+
+def test_legacy_dhs_cache_is_not_accepted(tmp_path):
+    """Dense DHS cache groups are recomputed instead of loaded as compact."""
+
+    filename = tmp_path / "legacy-dhs-cache.h5"
+    with precompute.h5py.File(filename, "w") as handle:
+        group = handle.create_group("Synthetic b")
+        group.attrs["filled"] = True
+        group.attrs["goodPA_list"] = [0]
+        group.create_dataset(
+            "target_trace", shape=(1, 2, 3), dtype="float32")
+        group.create_dataset(
+            "contamination", shape=(1, 2, 3), dtype="float32")
+        group.create_dataset("plane_index", data=[0])
+        assert not field_simulator._cached_contam_result_available(
+            group, compact_dhs=True)
+        assert field_simulator._cached_contam_result_available(
+            group, compact_dhs=False)
+
+
 def test_miri_pa_rotation_uses_siaf_coordinates():
     aperture = pysiaf.Siaf('MIRI')[miri_lrs.APERTURE]
     xdet, ydet = aperture.reference_point('det')


### PR DESCRIPTION
## Summary
- persist compact NIRCam DHS order fractions and position angles in the existing HDF5 target cache
- restore compact DHS results directly on a cache hit, without reconstructing a dense detector cube
- ignore legacy dense DHS entries so they are recomputed and replaced safely

This leaves the existing dense-cache path, float32 target-trace storage, and precomputed detector dimensions unchanged. Any already-existing DHS caches will need to be deleted and remade.

## Memory behavior
DHS target traces and fractional-contamination arrays are written one order at a time with bounded HDF5 chunks. Saving or loading the cache never constructs the former 360 x detector-row x detector-column cube.

A real 360-PA F322W2 Docker run took 144.9 s cold versus 0.89 s cached. Peak RAM was 2057.9 MiB cold and 580.8 MiB cached; enabling the cache increased cold-run peak RAM by only 0.5 MiB in a controlled comparison. The float64 order fractions were byte-identical after loading. The existing float32 target-trace storage had a measured maximum relative error of 5.96e-8.

## Tests
- 5 focused cache tests pass: exact float64 order-fraction round trips for F322W2 and F444W, cache-hit bypass of detector rendering, legacy DHS rejection, and the existing MIRI cache regression
- the GitHub Python matrix, Website Test, and Read the Docs build pass