### PR TITLE
Align contamination masks with reduced target traces

### DIFF
--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -878,9 +878,6 @@ def fraction_contaminated(aperture, targframes, starcube, trace_masks=None,
     list
         The list of fractional contamination arrays
     """
-    # Get target traces of interest only
-    trace_idx = APERTURES[aperture]['target_traces']
-
     # Check for 2D
     if starcube.ndim == 2:
         starcube = starcube[None, :, :]
@@ -891,8 +888,17 @@ def fraction_contaminated(aperture, targframes, starcube, trace_masks=None,
             trace_masks = miri_lrs.load_reference_trace().extraction_mask
         else:
             trace_masks = get_trace_mask(aperture, radius=20, plot=False)
-    if np.asarray(trace_masks).ndim == 2:
+        if np.asarray(trace_masks).ndim == 2:
+            trace_masks = [trace_masks]
+        trace_idx = APERTURES[aperture]['target_traces']
+        trace_masks = [trace_masks[idx] for idx in trace_idx]
+    elif np.asarray(trace_masks).ndim == 2:
         trace_masks = [trace_masks]
+
+    if len(trace_masks) != len(targframes):
+        raise ValueError(
+            'The number of trace masks must match the target frames')
+
     if collapse_axis is None:
         collapse_axis = (miri_lrs.CROSS_DISPERSION_AXIS
                          if aperture == miri_lrs.APERTURE else 0)
@@ -900,7 +906,6 @@ def fraction_contaminated(aperture, targframes, starcube, trace_masks=None,
     # Average only pixels inside each trace mask. Multiplying off-mask pixels
     # by zero would leave them finite and incorrectly count them in the mean.
     pctlines = []
-    trace_masks = [trace_masks[idx] for idx in trace_idx]
     for tframe, mask in zip(targframes, trace_masks):
         # Process one spectral trace at a time.  DHS has ten detector-sized
         # target traces, and retaining all sums and fractions simultaneously


### PR DESCRIPTION
## Summary

- Apply `target_traces` selection only to the complete mask set loaded internally by `fraction_contaminated()`.
- Treat masks supplied through `trace_masks` as already aligned one-for-one with `targframes`.
- Validate the final mask and target-frame counts instead of allowing `zip()` to silently discard unmatched entries.

## Why this is needed

The DHS changes intentionally retain fewer target outputs than physical contaminating traces: contaminants still require all ten DHS traces, while target contamination results retain eight. NIRISS/SOSS SUBSTRIP96 similarly models all three contaminating orders but retains only order 1 for the target result.

The current implementation applies `APERTURES[aperture]['target_traces']` to every mask collection. That is correct when `fraction_contaminated()` has just loaded the complete physical mask set itself. It is not correct when a caller supplies masks that already correspond to the reduced `targframes`: those masks are selected a second time, which can misalign masks and target frames or index beyond the supplied collection.

Keeping the selection at the point where the full mask set is loaded preserves `get_trace_mask()` as the source of all physical masks for contaminant modeling, while maintaining the existing `trace_masks` argument contract for callers and tests. The explicit length check also converts otherwise silent truncation into a clear error.

This is a stacked PR targeting `dhs_contam` for focused review.

## Verification

- `python -m py_compile exoctk/contam_visibility/field_simulator.py`
- CRLF-aware whitespace validation with `git diff --check`