### PR TITLE
Add AI policy for contributions using generative AI

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,22 @@
+# Usage of Generative AI
+
+STScI software maintainers welcome contributions, including those developed with the assistance of generative AI tools. However, the use of such tools does not change our expectations for contributor responsibility, engagement, or code quality. The following statements apply to all contributions. Pull requests that violate this policy will be closed.
+
+1. Prohibited Tools
+    1. Per STScI's AI policy, certain tools are prohibited and may not be used.  This currently includes, but may not be limited to, Deepseek and Grammerly.
+
+2. Human ownership and accountability
+    1. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
+    2. Contributors must understand and be able to explain all changes during review and address any concerns raised by maintainers.
+    3. Contributors are responsible for ensuring all submitted code complies with STScI licensing, regardless of whether generative AI tools were used.
+
+3. Disclosure
+    1. Presence of this `AI_POLICY.md` file indicates AI tools may have been used to assist with portions of this work.
+    2. Committers are encouraged to apply a label of `ai-assisted` to pull requests that leveraged AI tools.
+
+4. Authentic engagement
+    1. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback themselves. Copying and pasting replies to/from a generative AI tool does not count as engaging with the reviewer.
+All pull requests must be reviewed by a human other than the contributor.
+
+5. Consistency with repository conventions and existing style
+    1. In the context of Generative AI, this particularly means adhering to any linting standards as well as conveying information (comments, documentation, etc.) in a style the repository uses, and that is appropriate and to the point.


### PR DESCRIPTION
Added AI policy guidelines for contributors using generative AI tools, outlining prohibited tools, accountability, disclosure, engagement expectations, and consistency with repository conventions.