### PR TITLE
Resolving PyPI publication error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,9 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3"
-      - run: pip install build
+      - run: pip install build twine
       - run: python -m build --sdist --wheel
+      - run: python -m twine check dist/*
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
-.. image:: /exoctk/data/images/ExoCTK_logo.png
+.. image:: https://raw.githubusercontent.com/ExoCTK/exoctk/main/exoctk/data/images/ExoCTK_logo.png
     :alt: ExoCTK Logo
-    :scale: 5%
 
 .. image:: https://img.shields.io/github/release/ExoCTK/exoctk.svg
     :target: https://github.com/ExoCTK/exoctk/releases/latest/


### PR DESCRIPTION
Update build workflow to include twine and add check step; fix logo image path in README. Once this PR is merged, I will then make a v2026.7.1 GitHub release to trigger the PyPI publication