### PR TITLE
Fix contamination calculations for manually entered coordinates

### DIFF
--- a/exoctk/contam_visibility/field_simulator.py
+++ b/exoctk/contam_visibility/field_simulator.py
@@ -263,6 +263,20 @@ def contamination_supported(aperture):
     return aperture in WEB_CONTAMINATION_APERTURES
 
 
+def normalize_optional_target_name(target):
+    """Return ``None`` for an omitted target name.
+
+    WTForms supplies an empty string when users enter coordinates without a
+    target name.  Passing that value to ``get_canonical_name`` selects the
+    first entry in the exoplanet catalog (currently 11 Com b), which then
+    replaces the manually entered coordinates in contamination calculations.
+    """
+
+    if isinstance(target, str):
+        target = target.strip()
+    return target or None
+
+
 def source_query_width(aperture):
     """Return the Gaia query width needed to cover an aperture's sources.
 
@@ -590,6 +604,8 @@ def find_sources(ra=None, dec=None, target=None, width=5*u.arcmin,
     astropy.table.Table
         The table of stars
     """
+    target = normalize_optional_target_name(target)
+
     # Use ExoMAST for canonical exoplanet naming and SIMBAD for coordinates.
     # SIMBAD's basic identifier coordinates have an explicit J2000 contract,
     # unlike the coordinate values returned by ExoMAST.
@@ -1469,6 +1485,7 @@ def field_simulation(ra=None, dec=None, aperture=None, targname=None,
 
     # Preserve ExoMAST's canonical exoplanet name for cache compatibility,
     # while using SIMBAD's explicitly J2000 coordinates for Gaia matching.
+    targname = normalize_optional_target_name(targname)
     if targname is not None:
         targname = get_canonical_name(targname)
         ra, dec = resolve_target(targname)

--- a/exoctk/exoctk_app/app_exoctk.py
+++ b/exoctk/exoctk_app/app_exoctk.py
@@ -634,7 +634,8 @@ def contam_visibility():
                     'ra': ra_deg,
                     'dec': dec_deg,
                     'aperture': form.inst.data,
-                    'targname': form.targname.data,
+                    'targname': fs.normalize_optional_target_name(
+                        form.targname.data),
                     'target_date': form.epoch.data,
                     'coordinate_epoch': float(form.coordinate_epoch.data),
                 }
@@ -652,7 +653,8 @@ def contam_visibility():
                     'ra': ra_deg,
                     'dec': dec_deg,
                     'aperture': form.inst.data,
-                    'targname': form.targname.data,
+                    'targname': fs.normalize_optional_target_name(
+                        form.targname.data),
                     'target_date': form.epoch.data,
                     'coordinate_epoch': float(form.coordinate_epoch.data),
                 }

--- a/exoctk/tests/test_contam_visibility.py
+++ b/exoctk/tests/test_contam_visibility.py
@@ -80,6 +80,20 @@ def classification_row(mask_dsc=False, mask_columns=(), **values):
     return table[0]
 
 
+@pytest.mark.parametrize('target', [None, '', '   '])
+def test_blank_optional_target_name_is_absent(target):
+    """Manual-coordinate submissions must not resolve a catalog target."""
+
+    assert field_simulator.normalize_optional_target_name(target) is None
+
+
+def test_optional_target_name_is_stripped():
+    """Non-empty target names retain their normal resolution path."""
+
+    assert (field_simulator.normalize_optional_target_name('  WASP-39 b  ')
+            == 'WASP-39 b')
+
+
 def gaia_source_table(source_ids, excess_noise=0.):
     """Build a minimal Gaia result table for find_sources tests."""
 


### PR DESCRIPTION
## Summary

Fixes the Contamination & Visibility Calculator incorrectly resolving a blank
target-name field to `11 Com b` when users manually enter coordinates.

WTForms represents an empty target name as `""`. Because `field_simulation`
previously checked only `targname is not None`, the empty string was passed to
`get_canonical_name`, which selected the first exoplanet catalog entry and
replaced the submitted coordinates.

This caused the visibility plot to use the manually entered coordinates while
the contamination calculation and its V3PA observability mask used 11 Com b.

## Changes

- Normalize blank and whitespace-only target names to `None`.
- Normalize the value before dispatching contamination tasks.
- Apply the same normalization defensively inside `field_simulation` and
  `find_sources`.
- Add regression tests for blank, whitespace-only, and valid target names.

## Verification

Reproduced the issue through the local web → Redis → Celery workflow.

Before the fix, the worker replaced the submitted coordinates with 11 Com b
and returned V3PA ranges:

- 108–141 degrees
- 268–300 degrees

After the fix, the worker retained the submitted coordinates and returned the
expected ranges:

- 66–119 degrees
- 285–339 degrees

Targeted test result: 9 passed.